### PR TITLE
optimize and cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@
 - Keep root navigation and navbar home links aligned with the `/persons/list` landing behavior for authenticated users.
 - When changing spreadsheet parsing, validate against `test/assets/2016_timesheet_Luca-Pacioli.xlsx` and the expectations in `test/agiladmin/timesheet_test.clj`.
 - When changing config handling, verify both global config loading and per-project YAML loading.
+- Project configs are cached in memory by budgets path in `src/agiladmin/core.clj`; invalidate that cache when a flow adopts new repo contents, currently via `view_reload.clj`.
 - Be conservative around `view_timesheet/commit`; it mutates the budgets repo and pushes over SSH.
 - Avoid “cleanup” changes that rename columns, normalize casing differently, or alter dataset shapes unless you also update all dependent views/tests.
 - Frontend styling uses TailwindCSS + DaisyUI with the `nord` theme; shared layout helpers live in `src/agiladmin/webpage.clj`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@
 - When changing spreadsheet parsing, validate against `test/assets/2016_timesheet_Luca-Pacioli.xlsx` and the expectations in `test/agiladmin/timesheet_test.clj`.
 - When changing config handling, verify both global config loading and per-project YAML loading.
 - Project configs are cached in memory by budgets path in `src/agiladmin/core.clj`; invalidate that cache when a flow adopts new repo contents, currently via `view_reload.clj`.
+- Timesheet discovery and caching now assume direct-child workbook files under the budgets root; `src/agiladmin/view_timesheet.clj` invalidates the in-memory timesheet cache after a successful archive/push.
 - Be conservative around `view_timesheet/commit`; it mutates the budgets repo and pushes over SSH.
 - Avoid “cleanup” changes that rename columns, normalize casing differently, or alter dataset shapes unless you also update all dependent views/tests.
 - Frontend styling uses TailwindCSS + DaisyUI with the `nord` theme; shared layout helpers live in `src/agiladmin/webpage.clj`.

--- a/src/agiladmin/config.clj
+++ b/src/agiladmin/config.clj
@@ -289,19 +289,24 @@
 
 
 
-(defn load-project [conf proj]
-  (log/debug (str "Loading project: " proj))
-  (if-let [path (get (project-files conf) (upper-case proj))]
-    (let [pconf (yaml-read-safe path)]
-      (f/attempt-all
-       [_ (if (f/failed? pconf) pconf true)
-        entry-data (project-entry pconf proj path)
-        _validated (validate-data ProjectEntry
-                                  (:entry entry-data)
-                                  "project configuration"
-                                  path)]
-       {(:project-key entry-data)
-        (normalize-project-entry (:entry entry-data))}
-       (f/when-failed [e]
-         e)))
-    (f/fail (str "Project not found in budgets path: " proj))))
+(defn load-project
+  "Load one project config. A precomputed project-files map may be passed to
+  reuse one directory scan across a bulk loading pass."
+  ([conf proj]
+   (load-project conf (project-files conf) proj))
+  ([conf files proj]
+   (log/debug (str "Loading project: " proj))
+   (if-let [path (get files (upper-case proj))]
+     (let [pconf (yaml-read-safe path)]
+       (f/attempt-all
+        [_ (if (f/failed? pconf) pconf true)
+         entry-data (project-entry pconf proj path)
+         _validated (validate-data ProjectEntry
+                                   (:entry entry-data)
+                                   "project configuration"
+                                   path)]
+        {(:project-key entry-data)
+         (normalize-project-entry (:entry entry-data))}
+        (f/when-failed [e]
+          e)))
+     (f/fail (str "Project not found in budgets path: " proj)))))

--- a/src/agiladmin/core.clj
+++ b/src/agiladmin/core.clj
@@ -44,6 +44,9 @@
 ;; Memory-only project cache keyed by budgets path. Reload invalidates it when
 ;; the repo state changes, so no filesystem metadata or watcher is needed.
 (def project-cache (atom {}))
+;; Memory-only timesheet cache keyed by budgets path. Successful timesheet
+;; commits invalidate it after the repository adopts new workbook content.
+(def timesheet-cache (atom {}))
 
 (declare load-all-timesheets)
 (declare load-all-projects)
@@ -353,12 +356,25 @@
   ;;     wb))
 
   (defn load-all-timesheets
-    "load all timesheets in a directory matching a certain filename pattern"
+    "Load direct-child timesheets from a budgets directory, reusing an
+    in-memory cache until invalidate-timesheet-cache! is called for that path."
     [path regex]
-    (let [ts (util/list-files-matching path regex)]
-      (for [l (map #(.getName %) ts)]
-        (if (not= (first l) '\.)
-          (load-timesheet (str path l))))))
+    (let [cache-key path]
+      (if-let [cached-timesheets (get @timesheet-cache cache-key)]
+        cached-timesheets
+        (let [timesheets
+              (vec
+               (for [l (map #(.getName %) (util/list-direct-files-matching path regex))
+                     :when (not= (first l) '\.)]
+                 (load-timesheet (str path l))))]
+          (swap! timesheet-cache assoc cache-key timesheets)
+          timesheets))))
+
+(defn invalidate-timesheet-cache!
+  "Clear cached timesheets for one budgets path, or all paths with no arg."
+  ([] (reset! timesheet-cache {}))
+  ([path]
+   (swap! timesheet-cache dissoc path)))
 
 (defn- projects-cache-key
   [conf]

--- a/src/agiladmin/core.clj
+++ b/src/agiladmin/core.clj
@@ -41,6 +41,9 @@
 
 (def timesheet-cols-projects ["B" "C" "D" "E" "F" "G" "H"])
 (def timesheet-rows-hourtots [43 42 41 40 39 38])
+;; Memory-only project cache keyed by budgets path. Reload invalidates it when
+;; the repo state changes, so no filesystem metadata or watcher is needed.
+(def project-cache (atom {}))
 
 (declare load-all-timesheets)
 (declare load-all-projects)
@@ -357,18 +360,42 @@
         (if (not= (first l) '\.)
           (load-timesheet (str path l))))))
 
-  (defn load-all-projects [conf]
-    "load all project budgets specified in a directory"
-    (loop [[p & projects] (conf/project-names conf)
-           res {}]
-      (let [r (conf/load-project conf p)]
-        ;; cannot use failjure inside a loop/recur?
-        ;; tried (when (f/failed?)) here but no
-        ;; attempt all also cannot allow recur to be last
-        (if (f/failed? r)
-          (do
-            (log/warn (str "Skipping invalid project " p ": " (f/message r)))
-            (if (empty? projects) res
-                (recur projects res)))
-          (if (empty? projects) (conj r res)
-              (recur  projects  (conj r res)))))))
+(defn- projects-cache-key
+  [conf]
+  (get-in conf [:agiladmin :budgets :path]))
+
+(defn invalidate-project-cache!
+  "Clear cached project configs for one budgets path, or all paths with no arg."
+  ([] (reset! project-cache {}))
+  ([conf-or-path]
+   (swap! project-cache dissoc
+          (if (map? conf-or-path)
+            (projects-cache-key conf-or-path)
+            conf-or-path))))
+
+(defn- load-all-projects-fresh
+  [conf]
+  (let [files (conf/project-files conf)]
+    (reduce (fn [projects project-name]
+              (let [project (conf/load-project conf files project-name)]
+                (if (f/failed? project)
+                  (do
+                    (log/warn (str "Skipping invalid project "
+                                   project-name
+                                   ": "
+                                   (f/message project)))
+                    projects)
+                  (conj project projects))))
+            {}
+            (or (seq (get-in conf [:agiladmin :projects]))
+                (keys files)))))
+
+(defn load-all-projects [conf]
+  "Load project budgets for one budgets path, reusing an in-memory cache until
+  invalidate-project-cache! is called for that path."
+  (let [cache-key (projects-cache-key conf)]
+    (if-let [cached-projects (get @project-cache cache-key)]
+      cached-projects
+      (let [projects (load-all-projects-fresh conf)]
+        (swap! project-cache assoc cache-key projects)
+        projects))))

--- a/src/agiladmin/utils.clj
+++ b/src/agiladmin/utils.clj
@@ -82,6 +82,17 @@
             (map #(let [f (str/lower-case (.getName %))]
                     (if (re-find regex f) %)) files))))
 
+(defn list-direct-files-matching
+  "Return the direct child files of a directory whose names match a regexp.
+  Personnel and timesheet discovery use this on the budgets root only."
+  [directory regex]
+  (let [dir (io/file directory)
+        files (when (.isDirectory dir) (.listFiles dir))]
+    (->> files
+         (filter #(.isFile %))
+         (remove #(.startsWith (.getName %) "."))
+         (filter #(re-find regex (str/lower-case (.getName %)))))))
+
 (def regex-timesheet-to-name      (re-pattern "^\\d+_\\w+_(.*).xlsx$"))
 (def regex-budget-to-project-name (re-pattern "^.udget_(.*).xlsx$"))
 
@@ -139,4 +150,3 @@
      repo
      (qgit/find-rev-commit repo rev-walk "HEAD")
      path)))
-

--- a/src/agiladmin/view_person.clj
+++ b/src/agiladmin/view_person.clj
@@ -71,6 +71,20 @@
         tab/dataset
         to-table)))
 
+(defn- load-person-page-data
+  "Load the shared timesheet and project data needed by personnel pages."
+  [config person year]
+  (f/attempt-all
+   [ts-path (conf/q config [:agiladmin :budgets :path])
+    ts-file (util/name-year-to-timesheet person year)
+    timesheet (load-timesheet (str ts-path ts-file))
+    projects (load-all-projects config)
+    hours (map-timesheets [timesheet] load-monthly-hours (fn [_] true))]
+   {:ts-file ts-file
+    :timesheet timesheet
+    :projects projects
+    :hours hours}))
+
 (defn list-person-manager
   [config account person year]
   (web/render
@@ -79,12 +93,9 @@
     [:h1 (str year " - " (util/dotname person))]
     (view-timesheet/upload-card)
     (f/attempt-all
-     [ts-path (conf/q config [:agiladmin :budgets :path])
-      ts-file (util/name-year-to-timesheet person year)
-      timesheet (load-timesheet (str ts-path ts-file))
-      projects (load-all-projects config)
-      hours (map-timesheets [timesheet] load-monthly-hours (fn [_] true))]
-     (let [monthly-sections
+     [person-data (load-person-page-data config person year)]
+     (let [{:keys [ts-file timesheet projects hours]} person-data
+           monthly-sections
            (for [m (-> (range 1 13) vec rseq)
                  :let [worked (tab/filter-by hours {:month (str year '- m)})
                        mtot (tab/sum-col worked :hours)
@@ -126,7 +137,7 @@
   (if-not (s/admin? account)
     (web/render-error-page account "Unauthorized access")
     (let [year (:year (util/now))
-          people (->> (util/list-files-matching
+          people (->> (util/list-direct-files-matching
                        (conf/q config [:agiladmin :budgets :path])
                        #".*_timesheet_.*xlsx$")
                       (keep #(util/timesheet-to-name (.getName %)))
@@ -173,71 +184,76 @@
       [:h1 (str year " - " (util/dotname person))]
       (view-timesheet/upload-card)
       (f/attempt-all
-       [ts-path (conf/q config [:agiladmin :budgets :path])
-        ts-file (util/name-year-to-timesheet person year)
-        timesheet (load-timesheet (str ts-path ts-file))
-        projects (load-all-projects config)
-        costs (-> (map-timesheets
-                   [timesheet] load-monthly-hours (fn [_] true))
-                  (derive-costs config projects))]
-       [:div {:class "space-y-6"}
-        (person-download-timesheet ts-file) [:br]
-        (if (zero? (tab/sum-col costs :cost))
-          (web/render-error
-           (log/spy :error [:p "No costs found (blank timesheet)"]))
-          (let [voluntary-costs (tab/filter-by costs {:tag "VOL"})
-                billed-costs (tab/filter-rows costs
-                                              (fn [row]
-                                                (not (strcasecmp (:tag row) "VOL"))))
-                monthly-costs (tab/dataset
-                               (->> (:rows costs)
-                                    (group-by :month)
-                                    vals
-                                    (mapv (fn [rows]
-                                            {:cost (reduce + 0 (map :cost rows))}))))
-                monthly-average (-> (tab/average-col monthly-costs :cost)
-                                    util/round)]
-            [:div {:class "space-y-6"}
-             [:h1 "Yearly totals"]
-             (-> {:Total_hours (-> (tab/sum-col costs :hours) util/round)
-                  :Voluntary_hours (-> (tab/sum-col voluntary-costs :hours) util/round)
-                  :Total_billed (-> (tab/sum-col billed-costs :cost) util/round)
-                  :Monthly_average monthly-average}
-                 vector tab/dataset to-table)
-             (person-download-toolbar
-              person year
-              (into [["Date" "Name" "Project" "Task" "Tags" "Hours" "Cost" "CPH"]]
-                    (-> costs (derive-cost-per-hour config projects) tab/to-row-seq)))
-             [:div {:class "divider"}]
-             [:h1 "Monthly totals"]
-             (for [m (-> (range 1 13) vec rseq)
-                   :let [worked (tab/filter-by costs {:month (str year '- m)})
-                         mtot (tab/sum-col worked :hours)
-                         mvol (-> (tab/filter-by worked {:tag "VOL"})
-                                  (tab/sum-col :hours))
-                         pay (tab/sum-col worked :cost)
-                         breakdown (-> (derive-cost-per-hour worked config projects)
-                                       (tab/select-cols [:project :task :tag :hours :cost :cph]))]
-                   :when (> mtot 0)]
-               [:div {:class "card bg-base-100 shadow-sm"}
-                [:div {:class "card-body gap-3"}
-                 [:strong (util/month-name m)] " total bill for "
-                 (util/dotname person) " is "
-                 [:strong pay]
-                 " for " (- mtot mvol)
-                 " hours worked across "
-                 (keep #(when (= (:month %) (str year '- m))
-                          (:days %))
-                       (:sheets timesheet))
-                 " days, plus " mvol
-                 " voluntary hours."
-                 " (with 21% VAT added is " (+ pay (* pay 0.21)) ")"
-                 [:div {:class "month-detail overflow-x-auto"}
-                  (to-monthly-bill-table projects breakdown)]]])]))
-        (web/button-prev-year year person)]
+       [person-data (load-person-page-data config person year)]
+       (let [{:keys [ts-file timesheet projects hours]} person-data]
+         (f/attempt-all
+          [costs (derive-costs hours config projects)
+           costs-with-cph (derive-cost-per-hour costs config projects)]
+          [:div {:class "space-y-6"}
+           (person-download-timesheet ts-file)
+           [:br]
+           (if (zero? (tab/sum-col costs :cost))
+             (web/render-error
+              (log/spy :error [:p "No costs found (blank timesheet)"]))
+             (let [voluntary-costs (tab/filter-by costs {:tag "VOL"})
+                   billed-costs (tab/filter-rows costs
+                                                 (fn [row]
+                                                   (not (strcasecmp (:tag row) "VOL"))))
+                   monthly-costs (tab/dataset
+                                  (->> (:rows costs)
+                                       (group-by :month)
+                                       vals
+                                       (mapv (fn [rows]
+                                               {:cost (reduce + 0 (map :cost rows))}))))
+                   monthly-average (-> (tab/average-col monthly-costs :cost)
+                                       util/round)]
+               [:div {:class "space-y-6"}
+                [:h1 "Yearly totals"]
+                (-> {:Total_hours (-> (tab/sum-col costs :hours) util/round)
+                     :Voluntary_hours (-> (tab/sum-col voluntary-costs :hours) util/round)
+                     :Total_billed (-> (tab/sum-col billed-costs :cost) util/round)
+                     :Monthly_average monthly-average}
+                    vector tab/dataset to-table)
+                (person-download-toolbar
+                 person year
+                 (into [["Date" "Name" "Project" "Task" "Tags" "Hours" "Cost" "CPH"]]
+                       (tab/to-row-seq costs-with-cph)))
+                [:div {:class "divider"}]
+                [:h1 "Monthly totals"]
+                (for [m (-> (range 1 13) vec rseq)
+                      :let [worked (tab/filter-by costs {:month (str year '- m)})
+                            mtot (tab/sum-col worked :hours)
+                            mvol (-> (tab/filter-by worked {:tag "VOL"})
+                                     (tab/sum-col :hours))
+                            pay (tab/sum-col worked :cost)
+                            breakdown (-> (tab/filter-by costs-with-cph {:month (str year '- m)})
+                                          (tab/select-cols [:project :task :tag :hours :cost :cph]))]
+                      :when (> mtot 0)]
+                  [:div {:class "card bg-base-100 shadow-sm"}
+                   [:div {:class "card-body gap-3"}
+                    [:strong (util/month-name m)] " total bill for "
+                    (util/dotname person) " is "
+                    [:strong pay]
+                    " for " (- mtot mvol)
+                    " hours worked across "
+                    (keep #(when (= (:month %) (str year '- m))
+                             (:days %))
+                          (:sheets timesheet))
+                    " days, plus " mvol
+                    " voluntary hours."
+                    " (with 21% VAT added is " (+ pay (* pay 0.21)) ")"
+                    [:div {:class "month-detail overflow-x-auto"}
+                     (to-monthly-bill-table projects breakdown)]]])]))
+           (web/button-prev-year year person)]
+          (f/when-failed [e]
+            [:div
+             (web/render-error (f/message e))
+             (web/button-prev-year year person)])))
        (f/when-failed [e]
-         [:div (web/render-error (f/message e))
-          (web/button-prev-year year person)]))])
+         [:div
+          (web/render-error (f/message e))
+          (web/button-prev-year year person)]))
+      ])
     (list-person-manager config account person year)))
 
 (defn start

--- a/src/agiladmin/view_project.clj
+++ b/src/agiladmin/view_project.clj
@@ -92,220 +92,234 @@
    (f/when-failed [e]
      (web/render-error-page (f/message e)))))
 
-(defn h2020 [request config account]
-  (f/attempt-all
-   [projname     (s/param request :project)
-    project-conf (conf/load-project config projname)
-    conf         (get project-conf (keyword projname))
-    project-hours (if (s/can-view-costs? account)
-                    (project-costs config project-conf projname)
-                    (project-hours config projname))
-    task-details (-> project-hours
-                     (aggr :hours [:project :task])
-                     (derive-task-details project-conf))
-    empty-tasks (-> project-conf (derive-empty-tasks task-details))]
-   (web/render
-    account
-    [:div {:class "space-y-6"}
-     (if-not (empty? (:tasks conf))
-       [:div {:class "space-y-4"}
-        [:div {:class "flex flex-wrap items-center gap-3"}
-         [:h1 {:class "text-4xl font-semibold"} projname]
-         [:button {:class "btn btn-info ml-auto"
-                   :onclick "toggleMode(this)"} "Scale to Fit"]]
-        [:div {:class "rounded-box border border-base-300 bg-base-100 p-2 shadow-sm"}
-         [:div {:class "w-full min-h-80" :style "position: relative;" :id "gantt"}]]
-        (let [today (util/now)
-              gantt-tasks (map (fn [task]
-                                 (conj task {:progress
-                                             (some-> (tab/filter-by task-details {:task (:id task)})
-                                                     :rows
-                                                     first
-                                                     :progress)}))
-                               (:tasks conf))]
-          [:script {:type "text/javascript"}
-           (str "\nvar today = new Date("
-                (:year today)", "
-                (dec (:month today))", "
-                (:day today)");\n")
-           (str (slurp (io/resource "gantt-loader.js")) "
+(defn h2020
+  ([request config account]
+   (f/attempt-all
+    [projname (s/param request :project)
+     project-conf (conf/load-project config projname)
+     conf (get project-conf (keyword projname))]
+    (h2020 request config account projname project-conf conf)
+    (f/when-failed [e]
+      (web/render account (web/render-error (f/message e))))))
+  ([request config account projname project-conf conf]
+   (f/attempt-all
+    [project-hours (if (s/can-view-costs? account)
+                     (project-costs config project-conf projname)
+                     (project-hours config projname))
+     task-details (-> project-hours
+                      (aggr :hours [:project :task])
+                      (derive-task-details project-conf))
+     empty-tasks (-> project-conf (derive-empty-tasks task-details))]
+    (web/render
+     account
+     [:div {:class "space-y-6"}
+      (if-not (empty? (:tasks conf))
+        [:div {:class "space-y-4"}
+         [:div {:class "flex flex-wrap items-center gap-3"}
+          [:h1 {:class "text-4xl font-semibold"} projname]
+          [:button {:class "btn btn-info ml-auto"
+                    :onclick "toggleMode(this)"} "Scale to Fit"]]
+         [:div {:class "rounded-box border border-base-300 bg-base-100 p-2 shadow-sm"}
+          [:div {:class "w-full min-h-80" :style "position: relative;" :id "gantt"}]]
+         (let [today (util/now)
+               gantt-tasks (map (fn [task]
+                                  (conj task {:progress
+                                              (some-> (tab/filter-by task-details {:task (:id task)})
+                                                      :rows
+                                                      first
+                                                      :progress)}))
+                                (:tasks conf))]
+           [:script {:type "text/javascript"}
+            (str "\nvar today = new Date("
+                 (:year today)", "
+                 (dec (:month today))", "
+                 (:day today)");\n")
+            (str (slurp (io/resource "gantt-loader.js")) "
 var tasks = { data:" (chesh/generate-string gantt-tasks) "};
 gantt.init('gantt');
 gantt.parse(tasks);
 ")])]
-       [:h1 {:class "text-4xl font-semibold"} projname])
-     (when (s/admin? account)
-       (web/button "/projects/edit" "Edit project configuration"
-                   (hf/hidden-field "project" projname)
-                   "btn btn-primary btn-lg edit-project"))
-     [:div {:class "grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"}
-      [:div {:class "space-y-6"}
-       [:h1 (str "Totals - M "
-                 (let [lastm (:duration conf)
-                       currm (current-proj-month conf)]
-                   (str currm " / " lastm)))]
-       (let [hours (-> (tab/sum-col project-hours :hours) util/round)
-             tasks (:tasks conf)]
-         (if (s/can-view-costs? account)
-           (let [billed (-> (tab/sum-col project-hours :cost) util/round)]
-             (-> [{:total "Current"
-                   :cost billed
-                   :pm (-> hours (/ 150) util/round)
-                   :cph (if (or (zero? billed) (zero? hours))
-                          0
-                          (util/round (/ billed hours)))}]
-                 (concat
-                  (if (empty? tasks)
-                    []
-                    (let [max_hours (reduce + 0 (map #(* (get % :pm) 150) tasks))
-                          max_cost (* (:cph conf) max_hours)]
-                      [{:total "Progress"
-                        :cost (util/percentage billed max_cost)
-                        :pm (util/percentage hours max_hours)
-                        :CPH "⇧ ⇩"}
-                       {:total "Total"
-                        :cost max_cost
-                        :pm (/ max_hours 150)
-                        :CPH (:cph conf)}])))
-                 tab/dataset to-table))
-           (-> [{:total "Current"
-                 :hours hours
-                 :pm (-> hours (/ 150) util/round)}]
-               (concat
-                (if (empty? tasks)
-                  []
-                  (let [max_hours (reduce + 0 (map #(* (get % :pm) 150) tasks))]
-                    [{:total "Progress"
-                      :hours (util/percentage hours max_hours)
-                      :pm (util/percentage hours max_hours)}
-                     {:total "Total"
-                      :hours max_hours
-                      :pm (/ max_hours 150)}])))
-               tab/dataset to-table)))]
-       [:h2 "Overview of tasks"]
-       [:div {:class "overflow-x-auto"}
-        (let [overview-cols [:task :pm :h-left :start :end :progress :description]
-              used-tasks (tab/select-cols task-details overview-cols)
-              unused-tasks
-              (tab/dataset overview-cols
-                           (map (fn [row]
-                                  {:task (:id row)
-                                   :pm (:pm row)
-                                   :h-left nil
-                                   :start (:start_date row)
-                                   :end (:end_date row)
-                                   :progress nil
-                                   :description (:text row)})
-                                (:rows empty-tasks)))]
-          (-> (tab/append-rows overview-cols used-tasks unused-tasks)
-              (tab/order-by-col :task :asc)
-              to-table))]]
-      [:div {:class "space-y-4"}
-       [:h1 "Details " [:small "(switch views using tabs below)"]]
-       (web/tabs
-        (str "project-details-" projname)
-        [{:id "task-sum-hours"
-          :title "Task/Person totals"
-          :content [:div {:class "space-y-3"}
-                    [:h2 "Totals grouped per person and per task"]
-                    [:div {:class "overflow-x-auto"}
-                     (if (s/can-view-costs? account)
-                       (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
-                           (aggr [:hours :cost] [:name :tag :task])
-                           (tab/select-cols [:name :tag :task :hours :cost]) to-table)
-                       (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
-                           (aggr [:hours] [:name :tag :task])
-                           (tab/select-cols [:name :tag :task :hours]) to-table))]]}
-         {:id "task-totals"
-          :title "Task totals"
-          :content [:div {:class "space-y-3"}
-                    [:h2 "Totals per task"]
-                    [:div {:class "overflow-x-auto"}
-                     (-> task-details
-                         (tab/select-cols [:task :hours :tot-hours :pm :progress :description]) to-table)]]}
-         {:id "person-totals"
-          :title "Person totals"
-          :content [:div {:class "space-y-3"}
-                    [:h2 "Totals per person"]
-                    [:div {:class "overflow-x-auto"}
-                     (if (s/can-view-costs? account)
-                       (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
-                           (aggr [:hours :cost] [:name :tag])
-                           (tab/select-cols [:name :tag :hours :cost]) to-table)
-                       (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
-                           (aggr [:hours] [:name :tag])
-                           (tab/select-cols [:name :tag :hours]) to-table))]]}
-         {:id "monthly-details"
-          :title "Monthly details"
-          :content [:div {:class "space-y-3"}
-                    [:h2 "Detail of monthly hours used per person on each task"]
-                    [:div {:class "overflow-x-auto"}
-                     (if (s/can-view-costs? account)
-                       (-> project-hours
-                           (sort :month :desc)
-                           to-table)
-                       (-> project-hours
-                           (tab/select-cols [:month :name :task :hours])
-                           (sort :month :desc)
-                           to-table))]]}])]])
-   (f/when-failed [e]
-     (web/render account (web/render-error (f/message e))))))
+        [:h1 {:class "text-4xl font-semibold"} projname])
+      (when (s/admin? account)
+        (web/button "/projects/edit" "Edit project configuration"
+                    (hf/hidden-field "project" projname)
+                    "btn btn-primary btn-lg edit-project"))
+      [:div {:class "grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"}
+       [:div {:class "space-y-6"}
+        [:h1 (str "Totals - M "
+                  (let [lastm (:duration conf)
+                        currm (current-proj-month conf)]
+                    (str currm " / " lastm)))]
+        (let [hours (-> (tab/sum-col project-hours :hours) util/round)
+              tasks (:tasks conf)]
+          (if (s/can-view-costs? account)
+            (let [billed (-> (tab/sum-col project-hours :cost) util/round)]
+              (-> [{:total "Current"
+                    :cost billed
+                    :pm (-> hours (/ 150) util/round)
+                    :cph (if (or (zero? billed) (zero? hours))
+                           0
+                           (util/round (/ billed hours)))}]
+                  (concat
+                   (if (empty? tasks)
+                     []
+                     (let [max_hours (reduce + 0 (map #(* (get % :pm) 150) tasks))
+                           max_cost (* (:cph conf) max_hours)]
+                       [{:total "Progress"
+                         :cost (util/percentage billed max_cost)
+                         :pm (util/percentage hours max_hours)
+                         :CPH "⇧ ⇩"}
+                        {:total "Total"
+                         :cost max_cost
+                         :pm (/ max_hours 150)
+                         :CPH (:cph conf)}])))
+                  tab/dataset to-table))
+            (-> [{:total "Current"
+                  :hours hours
+                  :pm (-> hours (/ 150) util/round)}]
+                (concat
+                 (if (empty? tasks)
+                   []
+                   (let [max_hours (reduce + 0 (map #(* (get % :pm) 150) tasks))]
+                     [{:total "Progress"
+                       :hours (util/percentage hours max_hours)
+                       :pm (util/percentage hours max_hours)}
+                      {:total "Total"
+                       :hours max_hours
+                       :pm (/ max_hours 150)}])))
+                tab/dataset to-table)))]
+        [:h2 "Overview of tasks"]
+        [:div {:class "overflow-x-auto"}
+         (let [overview-cols [:task :pm :h-left :start :end :progress :description]
+               used-tasks (tab/select-cols task-details overview-cols)
+               unused-tasks
+               (tab/dataset overview-cols
+                            (map (fn [row]
+                                   {:task (:id row)
+                                    :pm (:pm row)
+                                    :h-left nil
+                                    :start (:start_date row)
+                                    :end (:end_date row)
+                                    :progress nil
+                                    :description (:text row)})
+                                 (:rows empty-tasks)))]
+           (-> (tab/append-rows overview-cols used-tasks unused-tasks)
+               (tab/order-by-col :task :asc)
+               to-table))]]
+       [:div {:class "space-y-4"}
+        [:h1 "Details " [:small "(switch views using tabs below)"]]
+        (web/tabs
+         (str "project-details-" projname)
+         [{:id "task-sum-hours"
+           :title "Task/Person totals"
+           :content [:div {:class "space-y-3"}
+                     [:h2 "Totals grouped per person and per task"]
+                     [:div {:class "overflow-x-auto"}
+                      (if (s/can-view-costs? account)
+                        (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
+                            (aggr [:hours :cost] [:name :tag :task])
+                            (tab/select-cols [:name :tag :task :hours :cost]) to-table)
+                        (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
+                            (aggr [:hours] [:name :tag :task])
+                            (tab/select-cols [:name :tag :task :hours]) to-table))]]}
+          {:id "task-totals"
+           :title "Task totals"
+           :content [:div {:class "space-y-3"}
+                     [:h2 "Totals per task"]
+                     [:div {:class "overflow-x-auto"}
+                      (-> task-details
+                          (tab/select-cols [:task :hours :tot-hours :pm :progress :description]) to-table)]]}
+          {:id "person-totals"
+           :title "Person totals"
+           :content [:div {:class "space-y-3"}
+                     [:h2 "Totals per person"]
+                     [:div {:class "overflow-x-auto"}
+                      (if (s/can-view-costs? account)
+                        (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
+                            (aggr [:hours :cost] [:name :tag])
+                            (tab/select-cols [:name :tag :hours :cost]) to-table)
+                        (-> (map-col project-hours :tag #(if (= "VOL" %) "VOL" ""))
+                            (aggr [:hours] [:name :tag])
+                            (tab/select-cols [:name :tag :hours]) to-table))]]}
+          {:id "monthly-details"
+           :title "Monthly details"
+           :content [:div {:class "space-y-3"}
+                     [:h2 "Detail of monthly hours used per person on each task"]
+                     [:div {:class "overflow-x-auto"}
+                      (if (s/can-view-costs? account)
+                        (-> project-hours
+                            (sort :month :desc)
+                            to-table)
+                        (-> project-hours
+                            (tab/select-cols [:month :name :task :hours])
+                            (sort :month :desc)
+                            to-table))]]}])]])
+    (f/when-failed [e]
+      (web/render account (web/render-error (f/message e)))))))
 
-(defn infra [config account projname]
-  (f/attempt-all
-   [project-conf (conf/load-project config projname)
-   conf         (get project-conf (keyword projname))
-   project-hours (-> (if (s/can-view-costs? account)
-                       (project-costs config project-conf projname)
-                       (project-hours config projname))
-                     (derive-years config project-conf))]
-  (web/render account [:div
-                       [:h1 (str projname " fixed costs overview")]
-                       [:h2 "Yearly totals"]
-                       (if (s/can-view-costs? account)
-                         (-> (aggr project-hours [:hours :cost] [:year :tag])
-                             (tab/select-cols [:year :tag :hours :cost])
-                             (sort :year :desc) to-table)
-                         (-> (aggr project-hours [:hours] [:year :tag])
-                             (tab/select-cols [:year :tag :hours])
-                             (sort :year :desc) to-table))
-                       [:h2 "Personnel totals"]
-                       (if (s/can-view-costs? account)
-                         (-> (aggr project-hours [:hours :cost] [:name :tag])
-                             (tab/select-cols [:name :tag :hours :cost])
-                             (sort :year :desc) to-table)
-                         (-> (aggr project-hours [:hours] [:name :tag])
-                             (tab/select-cols [:name :tag :hours])
-                             (sort :year :desc) to-table))
-                       ])))
+(defn infra
+  ([config account projname]
+   (f/attempt-all
+    [project-conf (conf/load-project config projname)
+     conf (get project-conf (keyword projname))]
+    (infra config account projname project-conf conf)))
+  ([config account projname project-conf conf]
+   (f/attempt-all
+    [project-hours (-> (if (s/can-view-costs? account)
+                         (project-costs config project-conf projname)
+                         (project-hours config projname))
+                       (derive-years config project-conf))]
+    (web/render account [:div
+                         [:h1 (str projname " fixed costs overview")]
+                         [:h2 "Yearly totals"]
+                         (if (s/can-view-costs? account)
+                           (-> (aggr project-hours [:hours :cost] [:year :tag])
+                               (tab/select-cols [:year :tag :hours :cost])
+                               (sort :year :desc) to-table)
+                           (-> (aggr project-hours [:hours] [:year :tag])
+                               (tab/select-cols [:year :tag :hours])
+                               (sort :year :desc) to-table))
+                         [:h2 "Personnel totals"]
+                         (if (s/can-view-costs? account)
+                           (-> (aggr project-hours [:hours :cost] [:name :tag])
+                               (tab/select-cols [:name :tag :hours :cost])
+                               (sort :year :desc) to-table)
+                           (-> (aggr project-hours [:hours] [:name :tag])
+                               (tab/select-cols [:name :tag :hours])
+                               (sort :year :desc) to-table))
+                         ]))))
 
-(defn rolling [config account projname]
-  (f/attempt-all
-   [project-conf (conf/load-project config projname)
-   conf         (get project-conf (keyword projname))
-   project-hours (-> (if (s/can-view-costs? account)
-                       (project-costs config project-conf projname)
-                       (project-hours config projname))
-                     (derive-years config project-conf))]
-  (web/render account [:div
-                       [:h1 (str projname " fixed costs overview")]
-                       [:h2 "Yearly totals"]
-                       (if (s/can-view-costs? account)
-                         (-> (aggr project-hours [:hours :cost] [:year :tag])
-                             (tab/select-cols [:year :tag :hours :cost])
-                             (sort :year :desc) to-table)
-                         (-> (aggr project-hours [:hours] [:year :tag])
-                             (tab/select-cols [:year :tag :hours])
-                             (sort :year :desc) to-table))
-                       [:h2 "Personnel totals"]
-                       (if (s/can-view-costs? account)
-                         (-> (aggr project-hours [:hours :cost] [:name :tag])
-                             (tab/select-cols [:name :tag :hours :cost])
-                             (sort :year :desc) to-table)
-                         (-> (aggr project-hours [:hours] [:name :tag])
-                             (tab/select-cols [:name :tag :hours])
-                             (sort :year :desc) to-table))
-                       ])))
+(defn rolling
+  ([config account projname]
+   (f/attempt-all
+    [project-conf (conf/load-project config projname)
+     conf (get project-conf (keyword projname))]
+    (rolling config account projname project-conf conf)))
+  ([config account projname project-conf conf]
+   (f/attempt-all
+    [project-hours (-> (if (s/can-view-costs? account)
+                         (project-costs config project-conf projname)
+                         (project-hours config projname))
+                       (derive-years config project-conf))]
+    (web/render account [:div
+                         [:h1 (str projname " fixed costs overview")]
+                         [:h2 "Yearly totals"]
+                         (if (s/can-view-costs? account)
+                           (-> (aggr project-hours [:hours :cost] [:year :tag])
+                               (tab/select-cols [:year :tag :hours :cost])
+                               (sort :year :desc) to-table)
+                           (-> (aggr project-hours [:hours] [:year :tag])
+                               (tab/select-cols [:year :tag :hours])
+                               (sort :year :desc) to-table))
+                         [:h2 "Personnel totals"]
+                         (if (s/can-view-costs? account)
+                           (-> (aggr project-hours [:hours :cost] [:name :tag])
+                               (tab/select-cols [:name :tag :hours :cost])
+                               (sort :year :desc) to-table)
+                           (-> (aggr project-hours [:hours] [:name :tag])
+                               (tab/select-cols [:name :tag :hours])
+                               (sort :year :desc) to-table))
+                         ]))))
 
 (defn start [request config account]
   (f/attempt-all
@@ -313,7 +327,7 @@ gantt.parse(tasks);
     project-conf (conf/load-project config projname)
     project      (get project-conf (keyword projname))]
    (cond
-     (= (:type project) "infra") (infra config account projname)
-     (= (:type project) "rolling") (rolling config account projname)
+     (= (:type project) "infra") (infra config account projname project-conf project)
+     (= (:type project) "rolling") (rolling config account projname project-conf project)
      :else
-     (h2020 request config account))))
+     (h2020 request config account projname project-conf project))))

--- a/src/agiladmin/view_reload.clj
+++ b/src/agiladmin/view_reload.clj
@@ -21,6 +21,7 @@
   (:require
    [clojure.java.io :as io]
    [agiladmin.webpage :as web]
+   [agiladmin.core :as core]
    [agiladmin.config :as conf]
    [taoensso.timbre :as log]
    [clj-jgit.porcelain :as git]))
@@ -102,6 +103,8 @@
                                     :passphrase ""
                                     :exclusive true}
                   (git/git-pull repo))]
+            ;; Adopted repo state changed, so request-time project reads must refresh.
+            (core/invalidate-project-cache! config)
             (render-repo-state-with-message
              account
              repo
@@ -131,6 +134,8 @@
       (if (.exists (io/file (str keypath ".pub")))
         (try
           (clone-budgets! budgets)
+          ;; First clone creates the live project tree for this budgets path.
+          (core/invalidate-project-cache! config)
           (if-let [repo (safe-load-repo (:path budgets))]
             (render-repo-state-with-message
              account

--- a/src/agiladmin/view_timesheet.clj
+++ b/src/agiladmin/view_timesheet.clj
@@ -21,6 +21,7 @@
    [clojure.string :as str]
    [clojure.java.io :as io]
    [agiladmin.core :refer :all]
+   [agiladmin.core :as core]
    [agiladmin.tabular :as tab]
    [agiladmin.utils :as util]
    [agiladmin.graphics :refer :all]
@@ -244,6 +245,7 @@ window.onload = dodiff;\n")]]])
           (if-let [gitrepo (safe-load-repo repo)]
             (let [keypath (conf/q conf [:agiladmin :budgets :ssh-key])
                   base-path (archive-timesheet! gitrepo path dst keypath req)]
+              (core/invalidate-timesheet-cache! repo)
               (render-workspace
                req
                acct

--- a/test/agiladmin/config_test.clj
+++ b/test/agiladmin/config_test.clj
@@ -1,6 +1,7 @@
 (ns agiladmin.config-test
   (:use midje.sweet)
   (:require [agiladmin.config :as conf]
+            [agiladmin.core :as core]
             [failjure.core :as f]
             [schema.core :as s]))
 
@@ -160,6 +161,73 @@
             proj (conf/load-project broken-config "INVALIDYAML")]
         (f/failed? proj) => true
         (f/message proj) => (contains "Invalid YAML at test/assets/INVALIDYAML.yaml")))
+
+(fact "Bulk project loads reuse one project file scan"
+      (let [calls (atom 0)
+            original-project-files @#'agiladmin.config/project-files
+            counting-config {:agiladmin {:budgets {:path "test/assets/"}}
+                             :filename "agiladmin.yaml"}]
+        (core/invalidate-project-cache! counting-config)
+        (with-redefs [agiladmin.config/project-files
+                      (fn [cfg]
+                        (swap! calls inc)
+                        (original-project-files cfg))]
+          (set (keys (core/load-all-projects counting-config)))
+          => #{:DIRECT :DUE :TRE :UNO}
+          @calls => 1)))
+
+(fact "Bulk project loads keep valid projects and skip invalid ones"
+      (let [projects (core/load-all-projects {:agiladmin {:budgets {:path "test/assets/"}}
+                                              :filename "agiladmin.yaml"})]
+        (set (keys projects)) => #{:DIRECT :DUE :TRE :UNO}
+        (get-in projects [:DIRECT :cph]) => 25
+        (get-in projects [:UNO :cph]) => 45
+        (contains? projects :BADFIELDS) => false
+        (contains? projects :BROKEN) => false
+        (contains? projects :INVALIDYAML) => false))
+
+(fact "Bulk project loads reuse cached projects for the same budgets path"
+      (let [calls (atom 0)
+            original-project-files @#'agiladmin.config/project-files
+            counting-config {:agiladmin {:budgets {:path "test/assets/"}}
+                             :filename "agiladmin.yaml"}]
+        (core/invalidate-project-cache! counting-config)
+        (with-redefs [agiladmin.config/project-files
+                      (fn [cfg]
+                        (swap! calls inc)
+                        (original-project-files cfg))]
+          (core/load-all-projects counting-config)
+          (core/load-all-projects counting-config)
+          @calls => 1)))
+
+(fact "Bulk project loads keep cache entries separated by budgets path"
+      (let [dir-a "/tmp/agiladmin-project-cache-a/"
+            dir-b "/tmp/agiladmin-project-cache-b/"
+            _ (.mkdirs (java.io.File. dir-a))
+            _ (.mkdirs (java.io.File. dir-b))
+            _ (spit (str dir-a "ALPHA.yaml") "ALPHA:\n  duration: 1\n")
+            _ (spit (str dir-b "BETA.yaml") "BETA:\n  duration: 2\n")
+            conf-a {:agiladmin {:budgets {:path dir-a}} :filename "agiladmin.yaml"}
+            conf-b {:agiladmin {:budgets {:path dir-b}} :filename "agiladmin.yaml"}]
+        (core/invalidate-project-cache! conf-a)
+        (core/invalidate-project-cache! conf-b)
+        (set (keys (core/load-all-projects conf-a))) => #{:ALPHA}
+        (set (keys (core/load-all-projects conf-b))) => #{:BETA}))
+
+(fact "Bulk project loads refresh after explicit cache invalidation"
+      (let [calls (atom 0)
+            original-project-files @#'agiladmin.config/project-files
+            counting-config {:agiladmin {:budgets {:path "test/assets/"}}
+                             :filename "agiladmin.yaml"}]
+        (core/invalidate-project-cache! counting-config)
+        (with-redefs [agiladmin.config/project-files
+                      (fn [cfg]
+                        (swap! calls inc)
+                        (original-project-files cfg))]
+          (core/load-all-projects counting-config)
+          (core/invalidate-project-cache! counting-config)
+          (core/load-all-projects counting-config)
+          @calls => 2)))
 
 (fact "Application config loader currently rejects runtime-only keys missing from the schema"
       (let [conf (conf/load-config "extra-keys-config" conf/default-settings)]

--- a/test/agiladmin/core_test.clj
+++ b/test/agiladmin/core_test.clj
@@ -138,3 +138,47 @@
                     :start_date "01-03-2026"
                     :duration 4
                     :pm 2}]}))
+
+(fact "Timesheet loads are cached per budgets path until invalidated"
+      (let [calls (atom 0)]
+        (core/invalidate-timesheet-cache!)
+        (with-redefs [agiladmin.utils/list-direct-files-matching
+                      (fn [_ _]
+                        [(java.io.File. "2026_timesheet_Ada-Lovelace.xlsx")])
+                      agiladmin.core/load-timesheet
+                      (fn [path]
+                        (swap! calls inc)
+                        {:file path})]
+          (core/load-all-timesheets "budgets/" #".*_timesheet_.*xlsx$")
+          (core/load-all-timesheets "budgets/" #".*_timesheet_.*xlsx$")
+          @calls => 1)))
+
+(fact "Timesheet caches are separated by budgets path"
+      (let [calls (atom [])]
+        (core/invalidate-timesheet-cache!)
+        (with-redefs [agiladmin.utils/list-direct-files-matching
+                      (fn [path _]
+                        [(java.io.File. (str path "2026_timesheet_User.xlsx"))])
+                      agiladmin.core/load-timesheet
+                      (fn [path]
+                        (swap! calls conj path)
+                        {:file path})]
+          (core/load-all-timesheets "budgets-a/" #".*_timesheet_.*xlsx$")
+          (core/load-all-timesheets "budgets-b/" #".*_timesheet_.*xlsx$")
+          @calls => ["budgets-a/2026_timesheet_User.xlsx"
+                     "budgets-b/2026_timesheet_User.xlsx"])))
+
+(fact "Timesheet cache invalidation forces a fresh reload"
+      (let [calls (atom 0)]
+        (core/invalidate-timesheet-cache!)
+        (with-redefs [agiladmin.utils/list-direct-files-matching
+                      (fn [_ _]
+                        [(java.io.File. "2026_timesheet_Ada-Lovelace.xlsx")])
+                      agiladmin.core/load-timesheet
+                      (fn [path]
+                        (swap! calls inc)
+                        {:file path})]
+          (core/load-all-timesheets "budgets/" #".*_timesheet_.*xlsx$")
+          (core/invalidate-timesheet-cache! "budgets/")
+          (core/load-all-timesheets "budgets/" #".*_timesheet_.*xlsx$")
+          @calls => 2)))

--- a/test/agiladmin/utils_test.clj
+++ b/test/agiladmin/utils_test.clj
@@ -45,3 +45,13 @@
       (fact "dotted name"
             (dotname (timesheet-to-name "2017_timesheet_Luca-Pacioli.xlsx")) => "L.Pacioli")
       )
+
+(fact "Direct file discovery ignores nested entries and hidden files"
+      (let [base "/tmp/agiladmin-utils-direct"
+            nested (str base "/nested")
+            _ (.mkdirs (java.io.File. nested))
+            _ (spit (str base "/2026_timesheet_Ada-Lovelace.xlsx") "ok")
+            _ (spit (str base "/.2026_timesheet_Hidden.xlsx") "hidden")
+            _ (spit (str nested "/2026_timesheet_Grace-Hopper.xlsx") "nested")
+            files (list-direct-files-matching base #".*_timesheet_.*xlsx$")]
+        (map #(.getName %) files) => ["2026_timesheet_Ada-Lovelace.xlsx"]))

--- a/test/agiladmin/version_test.clj
+++ b/test/agiladmin/version_test.clj
@@ -1,0 +1,12 @@
+(ns agiladmin.version-test
+  (:require [agiladmin.version :as version]
+            [midje.sweet :refer :all]))
+
+(fact "Version reads the baked classpath resource when present"
+      (let [tmp (doto (java.io.File/createTempFile "agiladmin-version" ".edn")
+                  (spit "{:version \"9.9.9\"}"))]
+        (with-redefs [clojure.java.io/resource
+                      (fn [path]
+                        (when (= path "agiladmin/version.edn")
+                          (.toURL (.toURI tmp))))]
+          (#'agiladmin.version/resource-version) => "9.9.9")))

--- a/test/agiladmin/view_person_test.clj
+++ b/test/agiladmin/view_person_test.clj
@@ -6,7 +6,7 @@
 
 (fact "Admin personnel view renders a compact filterable persons list"
       (with-redefs [agiladmin.utils/now (fn [] {:year 2026})
-                    agiladmin.utils/list-files-matching
+                    agiladmin.utils/list-direct-files-matching
                     (fn [_ _]
                       [(java.io.File. "2026_timesheet_Ada-Lovelace.xlsx")
                        (java.io.File. "2026_timesheet_Grace-Hopper.xlsx")])]
@@ -105,20 +105,17 @@
           (:body response) => "User Name:2026:user@example.org")))
 
 (fact "Manager personnel view omits cost output and yearly export controls"
-      (with-redefs [agiladmin.config/q (fn [_ _] "ignored/")
-                    agiladmin.utils/name-year-to-timesheet (fn [_ _] "ignored.xlsx")
-                    agiladmin.core/load-timesheet (fn [_]
-                                                   {:sheets [{:month "2026-1" :days 20}]})
-                    agiladmin.core/load-all-projects (fn [_]
-                                                      {:CORE {:idx {:TASK-1 {:text "Task one"}}}})
-                    agiladmin.core/map-timesheets
-                    (fn [& _]
-                      {:column-names [:month :project :task :tag :hours]
-                       :rows [{:month "2026-1"
-                               :project "CORE"
-                               :task "TASK-1"
-                               :tag ""
-                               :hours 12}]})]
+      (with-redefs [agiladmin.view-person/load-person-page-data
+                    (fn [_ _ _]
+                      {:ts-file "ignored.xlsx"
+                       :timesheet {:sheets [{:month "2026-1" :days 20}]}
+                       :projects {:CORE {:idx {:TASK-1 {:text "Task one"}}}}
+                       :hours {:column-names [:month :project :task :tag :hours]
+                               :rows [{:month "2026-1"
+                                       :project "CORE"
+                                       :task "TASK-1"
+                                       :tag ""
+                                       :hours 12}]}})]
         (let [response (view-person/list-person
                         {}
                         {:role "manager"
@@ -132,10 +129,8 @@
           (:body response) =not=> (contains "with 21% VAT added"))))
 
 (fact "Personnel view keeps the upload form visible when timesheet loading fails"
-      (with-redefs [agiladmin.config/q (fn [_ _] "ignored/")
-                    agiladmin.utils/name-year-to-timesheet (fn [_ _] "missing.xlsx")
-                    agiladmin.core/load-timesheet
-                    (fn [_]
+      (with-redefs [agiladmin.view-person/load-person-page-data
+                    (fn [_ _ _]
                       (failjure.core/fail "Missing timesheet"))]
         (let [response (view-person/list-person
                         {}
@@ -146,9 +141,64 @@
           (:body response) => (contains "Upload a new timesheet")
           (:body response) => (contains "Missing timesheet"))))
 
+(fact "Admin personnel view derives cost per hour once per request"
+      (let [cph-calls (atom 0)]
+        (with-redefs [agiladmin.view-person/load-person-page-data
+                      (fn [_ _ _]
+                        {:ts-file "ignored.xlsx"
+                         :timesheet {:sheets [{:month "2026-1" :days 20}
+                                              {:month "2026-2" :days 18}]}
+                         :projects {:CORE {:idx {:TASK-1 {:text "Task one"}}}}
+                         :hours {:column-names [:month :name :project :task :tag :hours]
+                                 :rows [{:month "2026-1"
+                                         :name "Admin User"
+                                         :project "CORE"
+                                         :task "TASK-1"
+                                         :tag ""
+                                         :hours 12}
+                                        {:month "2026-2"
+                                         :name "Admin User"
+                                         :project "CORE"
+                                         :task "TASK-1"
+                                         :tag ""
+                                         :hours 10}]}})
+                      agiladmin.core/derive-costs
+                      (fn [_ _ _]
+                        {:column-names [:month :name :project :task :tag :hours :cost]
+                         :rows [{:month "2026-1"
+                                 :name "Admin User"
+                                 :project "CORE"
+                                 :task "TASK-1"
+                                 :tag ""
+                                 :hours 12
+                                 :cost 1200}
+                                {:month "2026-2"
+                                 :name "Admin User"
+                                 :project "CORE"
+                                 :task "TASK-1"
+                                 :tag ""
+                                 :hours 10
+                                 :cost 1000}]})
+                      agiladmin.core/derive-cost-per-hour
+                      (fn [dataset _ _]
+                        (swap! cph-calls inc)
+                        (assoc dataset
+                               :column-names [:month :name :project :task :tag :hours :cost :cph]
+                               :rows (mapv #(assoc % :cph 100) (:rows dataset))))]
+          (let [response (view-person/list-person
+                          {}
+                          {:role "admin"
+                           :name "Admin User"}
+                          "Admin User"
+                          2026)]
+            @cph-calls => 1
+            (:body response) => (contains "Download yearly totals:")
+            (:body response) => (contains "2026-1")
+            (:body response) => (contains "2026-2")))))
+
 (fact "Admin personnel view ignores xlsx files that do not match the timesheet naming pattern"
       (with-redefs [agiladmin.utils/now (fn [] {:year 2026})
-                    agiladmin.utils/list-files-matching
+                    agiladmin.utils/list-direct-files-matching
                     (fn [_ _]
                       [(java.io.File. "2026_timesheet_User-Name.xlsx")
                        (java.io.File. "notes_timesheet_backup.xlsx")])
@@ -162,3 +212,16 @@
           (:body response) => (contains "Upload a new timesheet")
           (:body response) => (contains "User-Name")
           (:body response) =not=> (contains "notes_timesheet_backup"))))
+
+(fact "Admin personnel view collapses duplicate people discovered from timesheets"
+      (with-redefs [agiladmin.utils/now (fn [] {:year 2026})
+                    agiladmin.utils/list-direct-files-matching
+                    (fn [_ _]
+                      [(java.io.File. "2026_timesheet_Ada-Lovelace.xlsx")
+                       (java.io.File. "2025_timesheet_Ada-Lovelace.xlsx")])]
+        (let [response (view-person/list-all
+                        {}
+                        {:agiladmin {:budgets {:path "ignored/"}}}
+                        {:email "admin@example.org"
+                         :role "admin"})]
+          (count (re-seq #"data-text-filter-value=\"Ada-Lovelace\"" (:body response))) => 1)))

--- a/test/agiladmin/view_project_test.clj
+++ b/test/agiladmin/view_project_test.clj
@@ -4,13 +4,15 @@
             [midje.sweet :refer :all]))
 
 (fact "Project start dispatches infra projects to the infra view"
-      (let [calls (atom [])]
+      (let [calls (atom [])
+            load-calls (atom 0)]
         (with-redefs [agiladmin.config/load-project
                       (fn [_ _]
+                        (swap! load-calls inc)
                         {:CORE {:type "infra"}})
                       agiladmin.view-project/infra
-                      (fn [config account projname]
-                        (swap! calls conj [config account projname])
+                      (fn [config account projname project-conf project]
+                        (swap! calls conj [config account projname project-conf project])
                         {:status 200 :body "infra"})
                       agiladmin.view-project/rolling
                       (fn [& _] (throw (ex-info "unexpected rolling call" {})))
@@ -22,9 +24,12 @@
                           {:email "admin@example.org"})]
             (:status response) => 200
             (:body response) => "infra"
+            @load-calls => 1
             @calls => [[{:agiladmin {}}
                         {:email "admin@example.org"}
-                        "CORE"]]))))
+                        "CORE"
+                        {:CORE {:type "infra"}}
+                        {:type "infra"}]]))))
 
 (fact "Project list renders a compact filterable project list"
       (with-redefs [agiladmin.config/project-names
@@ -40,39 +45,45 @@
           (:body response) => (contains "inline-flex max-w-full w-full"))))
 
 (fact "Project start dispatches rolling projects to the rolling view"
-      (with-redefs [agiladmin.config/load-project
-                    (fn [_ _]
-                      {:CORE {:type "rolling"}})
+      (let [load-calls (atom 0)]
+        (with-redefs [agiladmin.config/load-project
+                      (fn [_ _]
+                        (swap! load-calls inc)
+                        {:CORE {:type "rolling"}})
                     agiladmin.view-project/rolling
-                    (fn [config account projname]
+                    (fn [config account projname project-conf project]
                       {:status 200 :body (str "rolling:" projname)})
                     agiladmin.view-project/infra
                     (fn [& _] (throw (ex-info "unexpected infra call" {})))
                     agiladmin.view-project/h2020
                     (fn [& _] (throw (ex-info "unexpected h2020 call" {})))]
-        (let [response (view-project/start
-                        {:params {:project "CORE"}}
-                        {}
-                        {:email "admin@example.org"})]
-          (:body response) => "rolling:CORE")))
+          (let [response (view-project/start
+                          {:params {:project "CORE"}}
+                          {}
+                          {:email "admin@example.org"})]
+            @load-calls => 1
+            (:body response) => "rolling:CORE"))))
 
 (fact "Project start dispatches default projects to the h2020 view"
-      (with-redefs [agiladmin.config/load-project
-                    (fn [_ _]
-                      {:CORE {:type "h2020"}})
+      (let [load-calls (atom 0)]
+        (with-redefs [agiladmin.config/load-project
+                      (fn [_ _]
+                        (swap! load-calls inc)
+                        {:CORE {:type "h2020"}})
                     agiladmin.view-project/h2020
-                    (fn [request config account]
+                    (fn [request config account projname project-conf project]
                       {:status 200
-                       :body (str "h2020:" (get-in request [:params :project]))})
+                       :body (str "h2020:" projname)})
                     agiladmin.view-project/infra
                     (fn [& _] (throw (ex-info "unexpected infra call" {})))
                     agiladmin.view-project/rolling
                     (fn [& _] (throw (ex-info "unexpected rolling call" {})))]
-        (let [response (view-project/start
-                        {:params {:project "CORE"}}
-                        {}
-                        {:email "admin@example.org"})]
-          (:body response) => "h2020:CORE")))
+          (let [response (view-project/start
+                          {:params {:project "CORE"}}
+                          {}
+                          {:email "admin@example.org"})]
+            @load-calls => 1
+            (:body response) => "h2020:CORE"))))
 
 (fact "Project edit renders an editor form when no edited yaml is submitted"
       (with-redefs [agiladmin.config/load-project

--- a/test/agiladmin/view_reload_test.clj
+++ b/test/agiladmin/view_reload_test.clj
@@ -27,12 +27,16 @@
           (:body response) => (contains "Budgets path exists but is not a git repository yet: budgets/"))))
 
 (fact "Reload page clones the budgets repository when the path is missing"
-      (let [clone-calls (atom [])]
+      (let [clone-calls (atom [])
+            invalidations (atom [])]
         (with-redefs [clojure.java.io/file
                       (fn [path]
                         (proxy [java.io.File] [path]
                           (isDirectory [] false)
                           (exists [] (str/ends-with? path ".pub"))))
+                      agiladmin.core/invalidate-project-cache!
+                      (fn [config]
+                        (swap! invalidations conj config))
                       agiladmin.view-reload/safe-load-repo
                       (fn [_] :repo)
                       clj-jgit.porcelain/with-identity
@@ -53,17 +57,22 @@
                                                  :ssh-key "id_rsa"}}}
                           {:email "admin"})]
             @clone-calls => [["git@example.org:repo.git" "budgets/"]]
+            (count @invalidations) => 1
             (:body response) => (contains "Cloned successfully from git@example.org:repo.git")))))
 
 (fact "Reload page clones the budgets repository when the directory is empty"
       (let [clone-calls (atom [])
-            repo-calls (atom 0)]
+            repo-calls (atom 0)
+            invalidations (atom [])]
         (with-redefs [clojure.java.io/file
                       (fn [path]
                         (proxy [java.io.File] [path]
                           (isDirectory [] (not (str/ends-with? path ".pub")))
                           (exists [] true)
                           (listFiles [] (into-array java.io.File []))))
+                      agiladmin.core/invalidate-project-cache!
+                      (fn [config]
+                        (swap! invalidations conj config))
                       clj-jgit.porcelain/with-identity
                       (fn [_ thunk]
                         (thunk))
@@ -87,26 +96,62 @@
                                                  :ssh-key "id_rsa"}}}
                           {:email "admin"})]
             @clone-calls => [["git@example.org:repo.git" "budgets/"]]
+            (count @invalidations) => 1
             (:body response) => (contains "Cloned successfully from git@example.org:repo.git")))))
 
+(fact "Reload page invalidates the project cache after a successful git pull"
+      (let [invalidations (atom [])]
+        (with-redefs [clojure.java.io/file
+                      (fn [_]
+                        (proxy [java.io.File] ["budgets"]
+                          (isDirectory [] true)
+                          (exists [] true)))
+                      agiladmin.core/invalidate-project-cache!
+                      (fn [config]
+                        (swap! invalidations conj config))
+                      agiladmin.view-reload/safe-load-repo
+                      (fn [_] :repo)
+                      clj-jgit.porcelain/with-identity
+                      (fn [_ thunk]
+                        (thunk))
+                      clj-jgit.porcelain/git-pull
+                      (fn [_] :pulled)
+                      clj-jgit.porcelain/git-status
+                      (fn [_] {:clean true})
+                      agiladmin.webpage/render-git-log
+                      (fn [_] [:div "log"])]
+          (let [response (view-reload/start
+                          {}
+                          {:agiladmin {:budgets {:path "budgets/"
+                                                 :git "git@example.org:repo.git"
+                                                 :ssh-key "id_rsa"}}}
+                          {:email "admin"})]
+            (count @invalidations) => 1
+            (:body response) => (contains "Reload completed.")))))
+
 (fact "Reload page renders an error when git pull fails"
-      (with-redefs [clojure.java.io/file
-                    (fn [_]
-                      (proxy [java.io.File] ["budgets"]
-                        (isDirectory [] true)
-                        (exists [] true)))
-                    agiladmin.view-reload/safe-load-repo
-                    (fn [_] :repo)
-                    clj-jgit.porcelain/with-identity
-                    (fn [_ thunk]
-                      (thunk))
-                    clj-jgit.porcelain/git-pull
-                    (fn [_]
-                      (throw (ex-info "Remote origin did not advertise Ref for branch master." {})))]
-        (let [response (view-reload/start
-                        {}
-                        {:agiladmin {:budgets {:path "budgets/"
-                                               :git "git@example.org:repo.git"
-                                               :ssh-key "id_rsa"}}}
-                        {:email "admin"})]
-          (:body response) => (contains "Error in git-pull: Remote origin did not advertise Ref for branch master."))))
+      (let [invalidations (atom [])]
+        (with-redefs [clojure.java.io/file
+                      (fn [_]
+                        (proxy [java.io.File] ["budgets"]
+                          (isDirectory [] true)
+                          (exists [] true)))
+                      agiladmin.core/invalidate-project-cache!
+                      (fn [config]
+                        (swap! invalidations conj config))
+                      agiladmin.view-reload/safe-load-repo
+                      (fn [_] :repo)
+                      clj-jgit.porcelain/with-identity
+                      (fn [_ thunk]
+                        (thunk))
+                      clj-jgit.porcelain/git-pull
+                      (fn [_]
+                        (throw (ex-info "Remote origin did not advertise Ref for branch master." {})))]
+          (let [response (view-reload/start
+                          {}
+                          {:agiladmin {:budgets {:path "budgets/"
+                                                 :git "git@example.org:repo.git"
+                                                 :ssh-key "id_rsa"}}}
+                          {:email "admin"})]
+            @invalidations => []
+            (:body response) => (contains "Error in git-pull: Remote origin did not advertise Ref for branch master.")))))

--- a/test/agiladmin/view_reload_test.clj
+++ b/test/agiladmin/view_reload_test.clj
@@ -15,7 +15,8 @@
                     (fn [_]
                       (proxy [java.io.File] ["budgets"]
                         (isDirectory [] true)
-                        (exists [] true)))
+                        (exists [] true)
+                        (listFiles [] (into-array java.io.File [(java.io.File. "placeholder")]))))
                     agiladmin.view-reload/safe-load-repo
                     (fn [_] nil)]
         (let [response (view-reload/start
@@ -105,7 +106,8 @@
                       (fn [_]
                         (proxy [java.io.File] ["budgets"]
                           (isDirectory [] true)
-                          (exists [] true)))
+                          (exists [] true)
+                          (listFiles [] (into-array java.io.File [(java.io.File. "placeholder")]))))
                       agiladmin.core/invalidate-project-cache!
                       (fn [config]
                         (swap! invalidations conj config))

--- a/test/agiladmin/view_timesheet_test.clj
+++ b/test/agiladmin/view_timesheet_test.clj
@@ -105,12 +105,16 @@
           (:body response) => (contains "Where is this file gone?! /tmp/upload.xlsx"))))
 
 (fact "Timesheet submit archives the upload and renders the success page"
-      (let [calls (atom [])]
+      (let [calls (atom [])
+            invalidations (atom [])]
         (with-redefs [clojure.java.io/file
                       (fn [path]
                         (proxy [java.io.File] [path]
                           (exists [] true)
                           (isDirectory [] (= path "budgets/"))))
+                      agiladmin.core/invalidate-timesheet-cache!
+                      (fn [path]
+                        (swap! invalidations conj path))
                       agiladmin.view-timesheet/safe-load-repo
                       (fn [_] :gitrepo)
                       agiladmin.view-timesheet/archive-timesheet!
@@ -137,6 +141,26 @@
                         "id_rsa"
                         {:name "Admin User"
                          :email "admin@example.org"}]]
+            @invalidations => ["budgets/"]
             (:body response) => (contains "Timesheet archived: upload.xlsx")
             (:body response) => (contains "Go back to Upload User")
             (:body response) => (contains "git log")))))
+
+(fact "Timesheet submit does not invalidate the cache on repository errors"
+      (let [invalidations (atom [])]
+        (with-redefs [clojure.java.io/file
+                      (fn [path]
+                        (proxy [java.io.File] [path]
+                          (exists [] true)
+                          (isDirectory [] true)))
+                      agiladmin.core/invalidate-timesheet-cache!
+                      (fn [path]
+                        (swap! invalidations conj path))
+                      agiladmin.view-timesheet/safe-load-repo
+                      (fn [_] nil)]
+          (let [response (view-timesheet/commit
+                          {:params {:path "/tmp/upload.xlsx"}}
+                          {:agiladmin {:budgets {:path "budgets/"}}}
+                          {:email "admin"})]
+            @invalidations => []
+            (:body response) => (contains "Timesheet submit is unavailable until the budgets directory is a git repository: budgets/")))))


### PR DESCRIPTION
This PR reduces repeated work in project loading without changing the storage model.

  Bulk project loads now scan the budgets directory once per fresh load and reuse that file index across all project YAML loads. Loaded projects are cached in memory by  budgets path, and the cache is invalidated only after a successful budgets git pull or git clone, so request-time reads stay fast without writing any cache files to  disk. Project route dispatch also avoids reloading the same project config twice in one request path.

  Tests were extended around bulk loading, cache reuse and invalidation, and project view dispatch.