### PR TITLE
Add Playwright E2E coverage for dev-auth login/upload and run it in CI

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -20,6 +20,12 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: npm
+
       - name: Set up Clojure CLI
         run: |
           curl -fsSL -O https://download.clojure.org/install/linux-install-1.12.4.1602.sh
@@ -35,6 +41,12 @@ jobs:
           key: ${{ runner.os }}-clojure-${{ hashFiles('deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-clojure-
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Download PocketBase
         env:
@@ -81,6 +93,9 @@ jobs:
       - name: Run tests
         run: make test CLOJURE=clojure
 
+      - name: Run Playwright E2E tests
+        run: npm run test:e2e
+
       - name: Run PocketBase integration tests
         env:
           AGILADMIN_PB_IT: "1"
@@ -98,3 +113,13 @@ jobs:
         if: failure()
         run: |
           test -f /tmp/pocketbase.log && cat /tmp/pocketbase.log || true
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            test-results
+            playwright-report
+            output/playwright/agiladmin-server.log

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ node_modules/
 .envrc
 __pycache__
 *.xlsx
+.tmp/
+output/playwright/
+test-results/
+playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@
   - build CSS and sync the local HTMX asset with `npm run build:frontend`
   - Tailwind input lives at `resources/tailwind.css`
   - generated stylesheet is `resources/public/static/css/app.css`
+- Browser E2E coverage uses Playwright:
+  - first-time setup: `npm ci` then `npx playwright install chromium`
+  - run suite: `npm run test:e2e` (dev auth harness, no PocketBase)
 
 ## Testing Reality
 - Existing tests are fixture-heavy and narrow.
@@ -86,6 +89,7 @@
   - auth backends and session behavior
   - selected route and view behavior
   - minimal `ring/init` smoke test
+  - browser login/upload path for admin and manager via Playwright harness
 - Not well covered:
   - HTTP route behavior
   - auth flows

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,12 +10,13 @@ POCKETBASE_APP_DIR ?= $(APP_HOME)/pocketbase
 POCKETBASE_MIGRATIONS_DIR ?= $(POCKETBASE_APP_DIR)/migrations
 JAR ?= target/$(BUILD_VERSION)-standalone.jar
 
-.PHONY: help test test-pocketbase-integration run dev run-pocketbase build install clean
+.PHONY: help test test-e2e test-pocketbase-integration run dev run-pocketbase build install clean
 
 help:
 	@printf '%s\n' \
 	  'Available targets:' \
 	  '  make test   Run the Midje test suite' \
+	  '  make test-e2e  Run Playwright login/upload browser tests with dev auth' \
 	  '  make test-pocketbase-integration  Run opt-in live PocketBase integration tests' \
 	  '  make run    Start the web application with dev auth fallback' \
 	  '  make dev    Start with request-time code reload enabled' \
@@ -26,6 +27,9 @@ help:
 
 test:
 	$(CLOJURE) -M:test
+
+test-e2e:
+	npm run test:e2e
 
 test-pocketbase-integration:
 	AGILADMIN_PB_IT=1 \

--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ Or:
 make test
 ```
 
+Run browser login/upload coverage (dev auth, no PocketBase):
+
+```sh
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
+
+The Playwright harness starts Agiladmin with an isolated temporary config and budgets directory, using dev credentials:
+
+- `admin:admin`
+- `manager:manager`
+
 The current test suite covers:
 
 - config loading and validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "agiladmin-frontend",
       "devDependencies": {
+        "@playwright/test": "^1.54.2",
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/github": "^11.0.6",
@@ -315,6 +316,22 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -5554,6 +5571,53 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "build:css": "tailwindcss -i ./resources/tailwind.css -o ./resources/public/static/css/app.css --minify",
     "sync:htmx": "node ./scripts/sync-frontend-assets.mjs",
     "build:frontend": "npm run sync:htmx && npm run build:css",
-    "test:e2e": "playwright test",
-    "test:e2e:headed": "playwright test --headed",
-    "test:e2e:debug": "playwright test --debug"
+    "test:e2e": "node ./scripts/e2e/run-playwright.mjs",
+    "test:e2e:headed": "node ./scripts/e2e/run-playwright.mjs --headed",
+    "test:e2e:debug": "node ./scripts/e2e/run-playwright.mjs --debug"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "scripts": {
     "build:css": "tailwindcss -i ./resources/tailwind.css -o ./resources/public/static/css/app.css --minify",
     "sync:htmx": "node ./scripts/sync-frontend-assets.mjs",
-    "build:frontend": "npm run sync:htmx && npm run build:css"
+    "build:frontend": "npm run sync:htmx && npm run build:css",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/github": "^11.0.6",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL: "http://127.0.0.1:18080",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/scripts/e2e/generate-manager-fixture.clj
+++ b/scripts/e2e/generate-manager-fixture.clj
@@ -1,0 +1,25 @@
+(ns agiladmin.e2e.generate-manager-fixture
+  (:require [dk.ative.docjure.spreadsheet :as xls]
+            [clojure.string :as str]))
+
+(defn- fail! [msg]
+  (binding [*out* *err*]
+    (println msg))
+  (System/exit 1))
+
+(defn -main [& args]
+  (let [[src dst owner] args
+        owner-name (or owner "Manager")]
+    (when (str/blank? src)
+      (fail! "Missing src path"))
+    (when (str/blank? dst)
+      (fail! "Missing dst path"))
+    (let [workbook (xls/load-workbook src)
+          sheet (first (xls/sheet-seq workbook))]
+      (when (nil? sheet)
+        (fail! "Workbook has no sheets"))
+      (xls/set-cell! (xls/select-cell "B3" sheet) owner-name)
+      (xls/save-workbook! dst workbook))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))

--- a/scripts/e2e/run-playwright.mjs
+++ b/scripts/e2e/run-playwright.mjs
@@ -1,0 +1,65 @@
+import { spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const args = process.argv.slice(2);
+let server;
+
+async function waitForLogin(url, timeoutMs = 90000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await fetch(url, { redirect: "manual" });
+      if (res.status >= 200 && res.status < 500) {
+        return;
+      }
+    } catch (_) {}
+    await sleep(1000);
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function main() {
+  server = spawn("node", ["./scripts/e2e/start-agiladmin.mjs"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  server.on("exit", (code) => {
+    if (code !== 0) {
+      console.error(`E2E server exited early with code ${code}`);
+    }
+  });
+
+  await waitForLogin("http://127.0.0.1:18080/login");
+
+  const runner = spawn("npx", ["playwright", "test", ...args], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  const testCode = await new Promise((resolve) => {
+    runner.on("exit", (code) => resolve(code ?? 1));
+  });
+
+  if (server && !server.killed) {
+    server.kill("SIGTERM");
+  }
+  process.exit(testCode);
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    if (server && !server.killed) {
+      server.kill("SIGTERM");
+    }
+    process.exit(130);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  if (server && !server.killed) {
+    server.kill("SIGTERM");
+  }
+  process.exit(1);
+});

--- a/scripts/e2e/start-agiladmin.mjs
+++ b/scripts/e2e/start-agiladmin.mjs
@@ -1,0 +1,150 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { createWriteStream } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+const TMP_ROOT_PREFIX = "agiladmin-e2e-";
+const STATE_DIR = path.join(REPO_ROOT, ".tmp");
+const STATE_PATH = path.join(STATE_DIR, "agiladmin-e2e-state.json");
+const OUTPUT_DIR = path.join(REPO_ROOT, "output", "playwright");
+const LOG_PATH = path.join(OUTPUT_DIR, "agiladmin-server.log");
+
+function yamlConfig(budgetsPath, sshKeyPath) {
+  return [
+    "appname: agiladmin-e2e",
+    "paths: []",
+    "filename: agiladmin-e2e.yaml",
+    "agiladmin:",
+    "  budgets:",
+    "    git: ssh://example.invalid/dyne/budgets",
+    `    path: ${JSON.stringify(`${budgetsPath}/`)}`,
+    `    ssh-key: ${JSON.stringify(sshKeyPath)}`,
+    "  source:",
+    "    git: https://github.com/dyne/agiladmin",
+    "    update: true",
+    "  webserver:",
+    "    host: 127.0.0.1",
+    "    port: 18080",
+    "    anti-forgery: false",
+  ].join("\n");
+}
+
+async function copyBudgetFixtures(targetDir) {
+  const srcDir = path.join(REPO_ROOT, "test", "assets");
+  const entries = await fs.readdir(srcDir, { withFileTypes: true });
+  const whitelist = new Set(["UNO.yaml", "DUE.yaml", "TRE.yaml", "BADFIELDS.yaml", "BROKEN.yaml", "INVALIDYAML.yaml"]);
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".yaml")) continue;
+    if (!whitelist.has(entry.name)) continue;
+    await fs.copyFile(path.join(srcDir, entry.name), path.join(targetDir, entry.name));
+  }
+}
+
+async function generateManagerFixture(adminFixturePath, managerFixturePath) {
+  const expr = [
+    "(load-file \"scripts/e2e/generate-manager-fixture.clj\")",
+    `(agiladmin.e2e.generate-manager-fixture/-main ${JSON.stringify(adminFixturePath)} ${JSON.stringify(managerFixturePath)} "Manager")`,
+  ].join(" ");
+  await new Promise((resolve, reject) => {
+    const child = spawn("clojure", ["-M", "-e", expr], {
+      cwd: REPO_ROOT,
+      stdio: "inherit",
+    });
+    child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`fixture generation failed: ${code}`))));
+    child.on("error", reject);
+  });
+}
+
+async function prepareEnv() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), TMP_ROOT_PREFIX));
+  const budgetsDir = path.join(tempRoot, "budgets");
+  const fixturesDir = path.join(tempRoot, "fixtures");
+  await fs.mkdir(budgetsDir, { recursive: true });
+  await fs.mkdir(fixturesDir, { recursive: true });
+  await fs.mkdir(STATE_DIR, { recursive: true });
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+
+  await copyBudgetFixtures(budgetsDir);
+
+  const sshKeyPath = path.join(tempRoot, "id_rsa");
+  await fs.copyFile(path.join(REPO_ROOT, "id_rsa"), sshKeyPath);
+  await fs.copyFile(path.join(REPO_ROOT, "id_rsa.pub"), `${sshKeyPath}.pub`);
+
+  const adminFixturePath = path.join(fixturesDir, "2016_timesheet_Luca-Pacioli.xlsx");
+  const managerFixturePath = path.join(fixturesDir, "2016_timesheet_Manager.xlsx");
+  await fs.copyFile(path.join(REPO_ROOT, "test", "assets", "2016_timesheet_Luca-Pacioli.xlsx"), adminFixturePath);
+  await generateManagerFixture(adminFixturePath, managerFixturePath);
+
+  const configPath = path.join(tempRoot, "agiladmin-e2e.yaml");
+  await fs.writeFile(configPath, `${yamlConfig(budgetsDir, sshKeyPath)}\n`, "utf8");
+
+  const state = {
+    tempRoot,
+    configPath,
+    budgetsDir,
+    fixtures: {
+      admin: adminFixturePath,
+      manager: managerFixturePath,
+    },
+    logPath: LOG_PATH,
+  };
+  await fs.writeFile(STATE_PATH, JSON.stringify(state, null, 2), "utf8");
+  return state;
+}
+
+async function start() {
+  const state = await prepareEnv();
+  const logStream = createWriteStream(LOG_PATH, { flags: "a" });
+  const child = spawn("clojure", ["-M:run"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      AGILADMIN_DEV_AUTH: "1",
+      AGILADMIN_CONF: state.configPath,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout.pipe(logStream);
+  child.stderr.pipe(logStream);
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+
+  const shutdown = async (signal) => {
+    if (!child.killed) {
+      child.kill("SIGTERM");
+    }
+    logStream.end();
+    try {
+      await fs.rm(state.tempRoot, { recursive: true, force: true });
+    } catch (_) {}
+    process.exit(signal === "exit" ? 0 : 130);
+  };
+
+  for (const sig of ["SIGINT", "SIGTERM"]) {
+    process.on(sig, () => {
+      shutdown(sig).catch((err) => {
+        console.error(err);
+        process.exit(1);
+      });
+    });
+  }
+  process.on("exit", () => {
+    if (!child.killed) child.kill("SIGTERM");
+  });
+
+  child.on("exit", async (code) => {
+    logStream.end();
+    try {
+      await fs.rm(state.tempRoot, { recursive: true, force: true });
+    } catch (_) {}
+    process.exit(code ?? 1);
+  });
+}
+
+start().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/e2e/helpers/agiladmin.js
+++ b/test/e2e/helpers/agiladmin.js
@@ -1,0 +1,30 @@
+import { expect } from "@playwright/test";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const STATE_PATH = path.resolve(process.cwd(), ".tmp/agiladmin-e2e-state.json");
+
+export async function readE2EState() {
+  const raw = await fs.readFile(STATE_PATH, "utf8");
+  return JSON.parse(raw);
+}
+
+export async function login(page, username, password) {
+  await page.goto("/login");
+  await page.locator('input[name="email"]').fill(username);
+  await page.locator('input[name="password"]').fill(password);
+  await page.locator('form[action="/login"] input[type="submit"]').click();
+  await expect(page.getByText(`Logged in: ${username}`)).toBeVisible();
+}
+
+export async function openTimesheetUpload(page) {
+  await page.goto("/timesheets");
+  await expect(page.locator("#timesheet-workspace")).toBeVisible();
+  await expect(page.locator('input[type="file"][name="file"]')).toBeVisible();
+}
+
+export async function uploadTimesheet(page, fixturePath) {
+  await page.locator('input[type="file"][name="file"]').setInputFiles(fixturePath);
+  await page.locator("#field-submit").click();
+  await expect(page.locator("#timesheet-workspace")).toBeVisible();
+}

--- a/test/e2e/timesheet-upload.spec.js
+++ b/test/e2e/timesheet-upload.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+import { login, openTimesheetUpload, readE2EState, uploadTimesheet } from "./helpers/agiladmin.js";
+
+test("admin can login and upload a real timesheet", async ({ page }) => {
+  const state = await readE2EState();
+  await login(page, "admin", "admin");
+  await openTimesheetUpload(page);
+  await uploadTimesheet(page, state.fixtures.admin);
+
+  await expect(page.getByText("Uploaded: 2016_timesheet_Luca-Pacioli.xlsx")).toBeVisible();
+  await page.getByRole("button", { name: "Contents" }).click();
+  await expect(page.getByText("Contents of the new timesheet")).toBeVisible();
+  await expect(page.getByText("Error parsing timesheet")).toHaveCount(0);
+});
+
+test("manager can login and upload their own timesheet", async ({ page }) => {
+  const state = await readE2EState();
+  await login(page, "manager", "manager");
+  await openTimesheetUpload(page);
+  await uploadTimesheet(page, state.fixtures.manager);
+
+  await expect(page.getByText("Uploaded: 2016_timesheet_Manager.xlsx")).toBeVisible();
+  await page.getByRole("button", { name: "Contents" }).click();
+  await expect(page.getByText("Contents of the new timesheet")).toBeVisible();
+  await expect(page.getByText("Error parsing timesheet")).toHaveCount(0);
+  await expect(page.getByText("Timesheet filename does not match the authenticated account")).toHaveCount(0);
+  await expect(page.getByText("Timesheet owner in cell B3 does not match the authenticated account")).toHaveCount(0);
+});
+
+test("manager upload rejects another person's timesheet", async ({ page }) => {
+  const state = await readE2EState();
+  await login(page, "manager", "manager");
+  await openTimesheetUpload(page);
+  await uploadTimesheet(page, state.fixtures.admin);
+
+  await expect(page.getByText("Timesheet filename does not match the authenticated account")).toBeVisible();
+});


### PR DESCRIPTION
 ## Summary

  This PR adds browser-level E2E coverage for the login + timesheet upload flow (dev auth, no PocketBase) and wires
  it into the pull-request CI workflow.

  ## What changed

  - Added Playwright test scaffolding and scripts:
      - npm run test:e2e
      - npm run test:e2e:headed
      - npm run test:e2e:debug
  - Added isolated E2E harness that:
      - creates temp config + budgets workspace
      - runs Agiladmin with AGILADMIN_DEV_AUTH=1
      - uses no PocketBase
      - generates a manager-owned .xlsx fixture from the real workbook fixture
  - Added E2E tests for:
      - admin login + upload happy path
      - manager login + own upload happy path
      - manager upload rejection for another user’s sheet
  - Updated CI (.github/workflows/test-and-build.yaml) to:
      - setup Node
      - run npm ci
      - install Playwright Chromium (--with-deps)
      - run npm run test:e2e
      - upload Playwright artifacts on failure
  - Added make test-e2e
  - Updated docs (README.md, AGENTS.md) and ignore rules for Playwright outputs

  ## Validation

  - Local run:
      - make test-e2e → 3 passed

  ## Notes

  - The current checkout did not reproduce an upload functional defect; browser coverage now guards the real web
    path in CI.