### PR TITLE
expand Playwright coverage for auth, role guards, visibility, and HTMX workflows

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -96,6 +96,7 @@ jobs:
       - name: Run tests
         run: make test CLOJURE=clojure
 
+      # Keep browser regressions separate from live PocketBase integration noise.
       - name: Run Playwright E2E tests
         run: npm run test:e2e
 

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -126,4 +126,5 @@ jobs:
           path: |
             test-results
             playwright-report
+            .tmp/agiladmin-e2e-state.json
             output/playwright/agiladmin-server.log

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -2,6 +2,9 @@ name: Test and Build
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -107,6 +110,7 @@ jobs:
         run: make test-pocketbase-integration CLOJURE=clojure
 
       - name: Build uberjar
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: make build CLOJURE=clojure
 
       - name: Print PocketBase log on failure

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Runtime budget baseline (local, April 28, 2026):
 
 - `make test-e2e`: 25 tests in about 19 seconds
 
+For CI/debug runs, set `DEBUG_E2E=1` to print generated harness paths (`state`, temp root, config, fixtures, server log) to stderr.
+
 The current test suite covers:
 
 - config loading and validation

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ The Playwright harness starts Agiladmin with an isolated temporary config and bu
 - `admin:admin`
 - `manager:manager`
 
+E2E conventions in this repo:
+
+- prefer direct route visits after login for authorization checks
+- assert user-visible behavior first (messages, links, forms)
+- keep submit/archive flows out of browser tests unless the test harness owns disposable git state
+
 The current test suite covers:
 
 - config loading and validation

--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ E2E conventions in this repo:
 - assert user-visible behavior first (messages, links, forms)
 - keep submit/archive flows out of browser tests unless the test harness owns disposable git state
 
+Current E2E spec grouping:
+
+- `test/e2e/authentication.spec.js`
+- `test/e2e/role-navigation.spec.js`
+- `test/e2e/personnel-visibility.spec.js`
+- `test/e2e/project-access.spec.js`
+- `test/e2e/project-visibility.spec.js`
+- `test/e2e/reload.spec.js`
+- `test/e2e/timesheet-upload.spec.js`
+
+Runtime budget baseline (local, April 28, 2026):
+
+- `make test-e2e`: 25 tests in about 19 seconds
+
 The current test suite covers:
 
 - config loading and validation

--- a/scripts/e2e/start-agiladmin.mjs
+++ b/scripts/e2e/start-agiladmin.mjs
@@ -42,10 +42,10 @@ async function copyBudgetFixtures(targetDir) {
   }
 }
 
-async function generateManagerFixture(adminFixturePath, managerFixturePath) {
+async function generateOwnedFixture(sourceFixturePath, targetFixturePath, ownerName) {
   const expr = [
     "(load-file \"scripts/e2e/generate-manager-fixture.clj\")",
-    `(agiladmin.e2e.generate-manager-fixture/-main ${JSON.stringify(adminFixturePath)} ${JSON.stringify(managerFixturePath)} "Manager")`,
+    `(agiladmin.e2e.generate-manager-fixture/-main ${JSON.stringify(sourceFixturePath)} ${JSON.stringify(targetFixturePath)} ${JSON.stringify(ownerName)})`,
   ].join(" ");
   await new Promise((resolve, reject) => {
     const child = spawn("clojure", ["-M", "-e", expr], {
@@ -74,8 +74,13 @@ async function prepareEnv() {
 
   const adminFixturePath = path.join(fixturesDir, "2016_timesheet_Luca-Pacioli.xlsx");
   const managerFixturePath = path.join(fixturesDir, "2016_timesheet_Manager.xlsx");
+  const guestFixturePath = path.join(fixturesDir, "2016_timesheet_Guest.xlsx");
   await fs.copyFile(path.join(REPO_ROOT, "test", "assets", "2016_timesheet_Luca-Pacioli.xlsx"), adminFixturePath);
-  await generateManagerFixture(adminFixturePath, managerFixturePath);
+  await generateOwnedFixture(adminFixturePath, managerFixturePath, "Manager");
+  await generateOwnedFixture(adminFixturePath, guestFixturePath, "Guest");
+
+  await fs.copyFile(managerFixturePath, path.join(budgetsDir, "2026_timesheet_Manager.xlsx"));
+  await fs.copyFile(guestFixturePath, path.join(budgetsDir, "2026_timesheet_Guest.xlsx"));
 
   const configPath = path.join(tempRoot, "agiladmin-e2e.yaml");
   await fs.writeFile(configPath, `${yamlConfig(budgetsDir, sshKeyPath)}\n`, "utf8");
@@ -87,6 +92,7 @@ async function prepareEnv() {
     fixtures: {
       admin: adminFixturePath,
       manager: managerFixturePath,
+      guest: guestFixturePath,
     },
     logPath: LOG_PATH,
   };

--- a/scripts/e2e/start-agiladmin.mjs
+++ b/scripts/e2e/start-agiladmin.mjs
@@ -10,6 +10,7 @@ const STATE_DIR = path.join(REPO_ROOT, ".tmp");
 const STATE_PATH = path.join(STATE_DIR, "agiladmin-e2e-state.json");
 const OUTPUT_DIR = path.join(REPO_ROOT, "output", "playwright");
 const LOG_PATH = path.join(OUTPUT_DIR, "agiladmin-server.log");
+const DEBUG_E2E = process.env.DEBUG_E2E === "1";
 
 function yamlConfig(budgetsPath, sshKeyPath) {
   return [
@@ -52,7 +53,17 @@ async function generateOwnedFixture(sourceFixturePath, targetFixturePath, ownerN
       cwd: REPO_ROOT,
       stdio: "inherit",
     });
-    child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`fixture generation failed: ${code}`))));
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `fixture generation failed for owner=${ownerName} source=${sourceFixturePath} target=${targetFixturePath} exit=${code}`,
+        ),
+      );
+    });
     child.on("error", reject);
   });
 }
@@ -97,6 +108,16 @@ async function prepareEnv() {
     logPath: LOG_PATH,
   };
   await fs.writeFile(STATE_PATH, JSON.stringify(state, null, 2), "utf8");
+  if (DEBUG_E2E) {
+    console.error("[DEBUG_E2E] state_path:", STATE_PATH);
+    console.error("[DEBUG_E2E] temp_root:", tempRoot);
+    console.error("[DEBUG_E2E] config_path:", configPath);
+    console.error("[DEBUG_E2E] budgets_dir:", budgetsDir);
+    console.error("[DEBUG_E2E] server_log:", LOG_PATH);
+    console.error("[DEBUG_E2E] fixture_admin:", adminFixturePath);
+    console.error("[DEBUG_E2E] fixture_manager:", managerFixturePath);
+    console.error("[DEBUG_E2E] fixture_guest:", guestFixturePath);
+  }
   return state;
 }
 

--- a/test/e2e/authentication.spec.js
+++ b/test/e2e/authentication.spec.js
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { expectLoginForm, loginAs, logout } from "./helpers/agiladmin.js";
+
+test("admin can login and logout", async ({ page }) => {
+  await loginAs(page, "admin");
+  await logout(page);
+  await page.goto("/timesheets");
+  await expectLoginForm(page);
+});
+
+test("manager can login and logout", async ({ page }) => {
+  await loginAs(page, "manager");
+  await logout(page);
+  await page.goto("/timesheets");
+  await expectLoginForm(page);
+});
+
+test("guest can login and logout", async ({ page }) => {
+  await loginAs(page, "guest");
+  await logout(page);
+  await page.goto("/timesheets");
+  await expectLoginForm(page);
+});
+
+test("invalid credentials fail without creating a session", async ({ page }) => {
+  await page.goto("/login");
+  await page.locator('input[name="email"]').fill("admin");
+  await page.locator('input[name="password"]').fill("wrong-password");
+  await page.locator('form[action="/login"] input[type="submit"]').click();
+
+  await expect(page.getByText("Login failed:")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Logout" })).toHaveCount(0);
+
+  await page.goto("/timesheets");
+  await expectLoginForm(page);
+});
+
+test("guest restrictions after login", async ({ page }) => {
+  await loginAs(page, "guest");
+
+  await page.goto("/projects/list");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+
+  await page.goto("/reload");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+
+  await page.goto("/config");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+
+  await page.goto("/persons/list");
+  await expect(page.getByRole("link", { name: "Logout" })).toBeVisible();
+  await expect(page.getByText("Personnel")).toHaveCount(0);
+});

--- a/test/e2e/helpers/agiladmin.js
+++ b/test/e2e/helpers/agiladmin.js
@@ -3,10 +3,19 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 const STATE_PATH = path.resolve(process.cwd(), ".tmp/agiladmin-e2e-state.json");
+export const USERS = {
+  admin: { username: "admin", password: "admin" },
+  manager: { username: "manager", password: "manager" },
+  guest: { username: "guest", password: "guest" },
+};
 
 export async function readE2EState() {
   const raw = await fs.readFile(STATE_PATH, "utf8");
-  return JSON.parse(raw);
+  const state = JSON.parse(raw);
+  for (const fixturePath of Object.values(state.fixtures || {})) {
+    await fs.access(fixturePath);
+  }
+  return state;
 }
 
 export async function login(page, username, password) {
@@ -14,7 +23,36 @@ export async function login(page, username, password) {
   await page.locator('input[name="email"]').fill(username);
   await page.locator('input[name="password"]').fill(password);
   await page.locator('form[action="/login"] input[type="submit"]').click();
+}
+
+export async function expectLoggedInAs(page, username) {
   await expect(page.getByText(`Logged in: ${username}`)).toBeVisible();
+}
+
+export async function expectLoginForm(page) {
+  await expect(page.locator('form[action="/login"]')).toBeVisible();
+  await expect(page.locator('input[name="email"]')).toBeVisible();
+  await expect(page.locator('input[name="password"]')).toBeVisible();
+}
+
+export async function loginAs(page, role) {
+  const user = USERS[role];
+  if (!user) {
+    throw new Error(`Unknown role: ${role}`);
+  }
+  await login(page, user.username, user.password);
+  if (role === "guest") {
+    await expect(page).toHaveURL(/\/persons\/list$/);
+    await expect(page.getByRole("link", { name: "Logout" })).toBeVisible();
+    await expect(page.locator('form[action="/login"]')).toHaveCount(0);
+    return;
+  }
+  await expectLoggedInAs(page, user.username);
+}
+
+export async function logout(page) {
+  await page.goto("/logout");
+  await expect(page.getByText("Logged out.")).toBeVisible();
 }
 
 export async function openTimesheetUpload(page) {

--- a/test/e2e/personnel-visibility.spec.js
+++ b/test/e2e/personnel-visibility.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers/agiladmin.js";
+
+test("admin sees personnel list including multiple people", async ({ page }) => {
+  await loginAs(page, "admin");
+  await page.goto("/persons/list");
+
+  await expect(page.getByRole("heading", { name: "Persons", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Manager", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Guest", exact: true })).toBeVisible();
+});
+
+test("manager sees own person page instead of the personnel list", async ({ page }) => {
+  await loginAs(page, "manager");
+  await page.goto("/persons/list");
+
+  await expect(page.getByRole("heading", { name: /Manager$/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Persons", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Guest", exact: true })).toHaveCount(0);
+});

--- a/test/e2e/project-access.spec.js
+++ b/test/e2e/project-access.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { expectLoginForm, loginAs } from "./helpers/agiladmin.js";
+
+async function openFirstProjectFromList(page) {
+  const candidates = ["DUE", "TRE", "UNO"];
+  let clicked = false;
+
+  for (const project of candidates) {
+    const button = page.getByRole("button", { name: project, exact: true });
+    if ((await button.count()) > 0) {
+      await button.first().click();
+      clicked = true;
+      break;
+    }
+  }
+
+  expect(clicked).toBeTruthy();
+  await expect(page.locator("#project-details .tabs")).toBeVisible();
+}
+
+test("admin can access project list and open a project", async ({ page }) => {
+  await loginAs(page, "admin");
+  await page.goto("/projects/list");
+  await openFirstProjectFromList(page);
+});
+
+test("manager can access project list and open a project", async ({ page }) => {
+  await loginAs(page, "manager");
+  await page.goto("/projects/list");
+  await openFirstProjectFromList(page);
+});
+
+test("guest is denied project list", async ({ page }) => {
+  await loginAs(page, "guest");
+  await page.goto("/projects/list");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+});
+
+test("logged out user is redirected to login for project list", async ({ page }) => {
+  await page.goto("/projects/list");
+  await expectLoginForm(page);
+});

--- a/test/e2e/project-visibility.spec.js
+++ b/test/e2e/project-visibility.spec.js
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers/agiladmin.js";
+
+async function openFirstProjectFromList(page) {
+  await page.goto("/projects/list");
+  const candidates = ["DUE", "TRE", "UNO"];
+  let clicked = false;
+
+  for (const project of candidates) {
+    const button = page.getByRole("button", { name: project, exact: true });
+    if ((await button.count()) > 0) {
+      await button.first().click();
+      clicked = true;
+      break;
+    }
+  }
+
+  expect(clicked).toBeTruthy();
+  await expect(page.locator("#project-details .tabs")).toBeVisible();
+}
+
+test("admin project view shows edit controls and cost data", async ({ page }) => {
+  await loginAs(page, "admin");
+  await openFirstProjectFromList(page);
+
+  await expect(page.getByText("Edit project configuration")).toBeVisible();
+  await expect(page.locator("th", { hasText: "Cost" }).first()).toBeVisible();
+});
+
+test("manager project view hides edit controls and cost data", async ({ page }) => {
+  await loginAs(page, "manager");
+  await openFirstProjectFromList(page);
+
+  await expect(page.getByText("Edit project configuration")).toHaveCount(0);
+  await expect(page.locator("th", { hasText: "Cost" })).toHaveCount(0);
+});
+
+test("manager direct project edit route is unauthorized", async ({ page }) => {
+  await loginAs(page, "manager");
+  const response = await page.request.post("/projects/edit", {
+    form: {
+      project: "DUE",
+    },
+  });
+  await expect(response.ok()).toBeTruthy();
+  const body = await response.text();
+  expect(body).toContain("Unauthorized access.");
+});

--- a/test/e2e/reload.spec.js
+++ b/test/e2e/reload.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers/agiladmin.js";
+
+test("admin reload keeps response in reload result container", async ({ page }) => {
+  await loginAs(page, "admin");
+  await page.goto("/reload");
+
+  await expect(page.getByRole("heading", { name: "Reload budgets repository" })).toBeVisible();
+  await page.getByRole("button", { name: "Reload", exact: true }).click();
+
+  const result = page.locator("#reload-result");
+  await expect(result).toBeVisible();
+  await expect(result).toContainText(
+    /(Reloaded successfully|Reload completed|not a git repository yet|Reload is unavailable)/,
+  );
+});
+
+test("manager is denied reload page", async ({ page }) => {
+  await loginAs(page, "manager");
+  await page.goto("/reload");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+});

--- a/test/e2e/role-navigation.spec.js
+++ b/test/e2e/role-navigation.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+import { expectLoginForm, loginAs } from "./helpers/agiladmin.js";
+
+test("admin navbar shows admin and project entries", async ({ page }) => {
+  await loginAs(page, "admin");
+  await page.goto("/persons/list");
+
+  await expect(page.getByRole("link", { name: "Personnel" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Projects" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Reload" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Configuration" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Logout" })).toBeVisible();
+});
+
+test("manager navbar hides admin-only entries", async ({ page }) => {
+  await loginAs(page, "manager");
+  await page.goto("/persons/list");
+
+  await expect(page.getByRole("link", { name: "Projects" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Personnel" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Reload" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Configuration" })).toHaveCount(0);
+});
+
+test("guest navbar hides project and admin entries", async ({ page }) => {
+  await loginAs(page, "guest");
+  await page.goto("/persons/list");
+
+  await expect(page.getByRole("link", { name: "Projects" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Reload" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Configuration" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Logout" })).toBeVisible();
+});
+
+test("guarded admin routes enforce role restrictions", async ({ page, context }) => {
+  await page.goto("/reload");
+  await expectLoginForm(page);
+
+  await context.clearCookies();
+  await loginAs(page, "manager");
+  await page.goto("/reload");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+  await page.goto("/config");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+  await page.goto("/config/edit");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+
+  await context.clearCookies();
+  await loginAs(page, "guest");
+  await page.goto("/reload");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+  await page.goto("/config");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+  await page.goto("/config/edit");
+  await expect(page.getByText("Unauthorized access.")).toBeVisible();
+
+  await context.clearCookies();
+  await loginAs(page, "admin");
+  await page.goto("/reload");
+  await expect(page.getByText("Reload budgets repository")).toBeVisible();
+  await page.goto("/config");
+  await expect(page.getByText("SSH authentication keys")).toBeVisible();
+  await page.goto("/config/edit");
+  await expect(page.getByText("Configuration editor")).toBeVisible();
+});

--- a/test/e2e/timesheet-upload.spec.js
+++ b/test/e2e/timesheet-upload.spec.js
@@ -1,9 +1,9 @@
 import { test, expect } from "@playwright/test";
-import { login, openTimesheetUpload, readE2EState, uploadTimesheet } from "./helpers/agiladmin.js";
+import { loginAs, openTimesheetUpload, readE2EState, uploadTimesheet } from "./helpers/agiladmin.js";
 
 test("admin can login and upload a real timesheet", async ({ page }) => {
   const state = await readE2EState();
-  await login(page, "admin", "admin");
+  await loginAs(page, "admin");
   await openTimesheetUpload(page);
   await uploadTimesheet(page, state.fixtures.admin);
 
@@ -15,7 +15,7 @@ test("admin can login and upload a real timesheet", async ({ page }) => {
 
 test("manager can login and upload their own timesheet", async ({ page }) => {
   const state = await readE2EState();
-  await login(page, "manager", "manager");
+  await loginAs(page, "manager");
   await openTimesheetUpload(page);
   await uploadTimesheet(page, state.fixtures.manager);
 
@@ -29,7 +29,7 @@ test("manager can login and upload their own timesheet", async ({ page }) => {
 
 test("manager upload rejects another person's timesheet", async ({ page }) => {
   const state = await readE2EState();
-  await login(page, "manager", "manager");
+  await loginAs(page, "manager");
   await openTimesheetUpload(page);
   await uploadTimesheet(page, state.fixtures.admin);
 

--- a/test/e2e/timesheet-upload.spec.js
+++ b/test/e2e/timesheet-upload.spec.js
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { loginAs, openTimesheetUpload, readE2EState, uploadTimesheet } from "./helpers/agiladmin.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 test("admin can login and upload a real timesheet", async ({ page }) => {
   const state = await readE2EState();
@@ -34,4 +37,18 @@ test("manager upload rejects another person's timesheet", async ({ page }) => {
   await uploadTimesheet(page, state.fixtures.admin);
 
   await expect(page.getByText("Timesheet filename does not match the authenticated account")).toBeVisible();
+});
+
+test("upload error keeps workflow in timesheet workspace", async ({ page }) => {
+  const invalidPath = path.join(os.tmpdir(), `agiladmin-e2e-invalid-${Date.now()}.txt`);
+  await fs.writeFile(invalidPath, "not an xlsx", "utf8");
+
+  await loginAs(page, "admin");
+  await openTimesheetUpload(page);
+  await uploadTimesheet(page, invalidPath);
+
+  await expect(page).toHaveURL(/\/timesheets$/);
+  await expect(page.locator("#timesheet-workspace")).toBeVisible();
+  await expect(page.getByText("Error parsing timesheet")).toBeVisible();
+  await expect(page.locator('input[type="file"][name="file"]')).toBeVisible();
 });

--- a/test/e2e/timesheet-upload.spec.js
+++ b/test/e2e/timesheet-upload.spec.js
@@ -52,3 +52,14 @@ test("upload error keeps workflow in timesheet workspace", async ({ page }) => {
   await expect(page.getByText("Error parsing timesheet")).toBeVisible();
   await expect(page.locator('input[type="file"][name="file"]')).toBeVisible();
 });
+
+test("cancel after upload returns to upload form", async ({ page }) => {
+  const state = await readE2EState();
+  await loginAs(page, "admin");
+  await openTimesheetUpload(page);
+  await uploadTimesheet(page, state.fixtures.admin);
+
+  await page.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(page.getByText("Canceled upload of timesheet:")).toBeVisible();
+  await expect(page.locator('input[type="file"][name="file"]')).toBeVisible();
+});


### PR DESCRIPTION
This PR extends the Playwright E2E suite in the dev-auth mock environment (no PocketBase) to cover high-risk
  browser behavior that unit tests were not catching.

  ### What was added

  - Broader auth/session coverage:
      - login/logout for admin, manager, guest
      - invalid login does not create session
      - guest restricted-route checks
  - Role-based navigation and route guards:
      - navbar visibility assertions for admin/manager/guest
      - direct URL guard checks for /reload, /config, /config/edit
  - Project access and visibility:
      - admin/manager can open project views
      - guest/logged-out denied project access
      - manager cannot access /projects/edit
      - admin sees edit/cost affordances; manager does not
  - Personnel visibility restrictions:
      - admin sees personnel list
      - manager is scoped to own person page
  - HTMX/progressive workflow coverage:
      - upload parse errors stay in #timesheet-workspace with retry form visible
      - reload action updates #reload-result for admin; denied for manager
      - cancel after upload returns to upload form

  ### Test files added

  - test/e2e/authentication.spec.js
  - test/e2e/role-navigation.spec.js
  - test/e2e/project-access.spec.js
  - test/e2e/project-visibility.spec.js
  - test/e2e/personnel-visibility.spec.js
  - test/e2e/reload.spec.js

  ### Test files updated

  - test/e2e/timesheet-upload.spec.js
  - test/e2e/helpers/agiladmin.js
  - scripts/e2e/start-agiladmin.mjs
  - README.md (E2E conventions note)

  ### Verification

  - Targeted spec runs passed while implementing each slice.
  - Full suite passed locally: make test-e2e (25 passed).